### PR TITLE
Feat/signal

### DIFF
--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -16,6 +16,7 @@
 # include "libft.h"
 # include "macros.h"
 # include "structs.h"
+# include "../sources/handler/signals.h"
 
 # include <fcntl.h>
 # include <stdio.h>

--- a/sources/executor/process.c
+++ b/sources/executor/process.c
@@ -6,7 +6,7 @@
 /*   By: peda-cos <peda-cos@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/25 08:19:21 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/03/25 08:24:47 by peda-cos         ###   ########.fr       */
+/*   Updated: 2025/03/29 15:15:49 by peda-cos         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -36,6 +36,7 @@ void	child_process(t_command *cmd, int pipefd[2], char **env, int *last_exit)
 {
 	if (!cmd || !env || !last_exit)
 		exit(1);
+	reset_signals();
 	if (cmd->next && pipefd[1] > 0)
 	{
 		dup2(pipefd[1], STDOUT_FILENO);

--- a/sources/handler/main.c
+++ b/sources/handler/main.c
@@ -3,25 +3,83 @@
 /*                                                        :::      ::::::::   */
 /*   main.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
+/*   By: peda-cos <peda-cos@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/26 17:56:00 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/03/22 18:44:16 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/03/29 15:35:54 by peda-cos         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "minishell.h"
+#include "signals.h"
 
 volatile sig_atomic_t	g_signal_received = 0;
 
-void	signal_handler(int signo)
+static void	interactive_sigint_handler(int signo)
 {
+	(void)signo;
+	g_signal_received = SIGINT;
+	write(STDOUT_FILENO, "\n", 1);
+	rl_on_new_line();
+	rl_replace_line("", 0);
+	rl_redisplay();
+}
+
+static void	execution_signal_handler(int signo)
+{
+	g_signal_received = signo;
 	if (signo == SIGINT)
-	{
-		g_signal_received = SIGINT;
 		write(STDOUT_FILENO, "\n", 1);
-		rl_on_new_line();
-		rl_replace_line("", 0);
-		rl_redisplay();
+	else if (signo == SIGQUIT)
+		write(STDOUT_FILENO, "Quit (core dumped)\n", 20);
+}
+
+void	setup_interactive_signals(void)
+{
+	struct sigaction	sa_int;
+	struct sigaction	sa_quit;
+
+	sigemptyset(&sa_int.sa_mask);
+	sa_int.sa_flags = 0;
+	sa_int.sa_handler = &interactive_sigint_handler;
+	sigaction(SIGINT, &sa_int, NULL);
+	sigemptyset(&sa_quit.sa_mask);
+	sa_quit.sa_flags = 0;
+	sa_quit.sa_handler = SIG_IGN;
+	sigaction(SIGQUIT, &sa_quit, NULL);
+}
+
+void	setup_execution_signals(void)
+{
+	struct sigaction	sa_int;
+	struct sigaction	sa_quit;
+
+	sigemptyset(&sa_int.sa_mask);
+	sa_int.sa_flags = 0;
+	sa_int.sa_handler = &execution_signal_handler;
+	sigaction(SIGINT, &sa_int, NULL);
+	sigemptyset(&sa_quit.sa_mask);
+	sa_quit.sa_flags = 0;
+	sa_quit.sa_handler = &execution_signal_handler;
+	sigaction(SIGQUIT, &sa_quit, NULL);
+}
+
+void	reset_signals(void)
+{
+	struct sigaction	sa;
+
+	sigemptyset(&sa.sa_mask);
+	sa.sa_flags = 0;
+	sa.sa_handler = SIG_DFL;
+	sigaction(SIGINT, &sa, NULL);
+	sigaction(SIGQUIT, &sa, NULL);
+}
+
+int	handle_eof(char *input)
+{
+	if (!input)
+	{
+		write(STDOUT_FILENO, "exit\n", 5);
+		return (1);
 	}
+	return (0);
 }

--- a/sources/handler/signals.h
+++ b/sources/handler/signals.h
@@ -1,0 +1,45 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   signals.h                                          :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: peda-cos <peda-cos@student.42sp.org.br>    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/03/29 15:18:06 by peda-cos          #+#    #+#             */
+/*   Updated: 2025/03/29 15:40:10 by peda-cos         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#ifndef SIGNALS_H
+# define SIGNALS_H
+
+# include "minishell.h"
+
+/**
+ * Global signal flag to indicate which signal was received
+ * Used to communicate signal events between signal handlers and main code
+ */
+extern volatile __sig_atomic_t	g_signal_received;
+
+/**
+ * Setup signal handling for interactive mode (prompt)
+ */
+void							setup_interactive_signals(void);
+
+/**
+ * Setup signal handling for command execution mode
+ */
+void							setup_execution_signals(void);
+
+/**
+ * Reset signals to default behavior
+ */
+void							reset_signals(void);
+
+/**
+ * Handle EOF (Ctrl+D) in interactive mode
+ * Returns 1 if shell should exit, 0 otherwise
+ */
+int								handle_eof(char *input);
+
+#endif

--- a/sources/main.c
+++ b/sources/main.c
@@ -6,7 +6,7 @@
 /*   By: peda-cos <peda-cos@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/19 19:05:27 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/02/27 13:42:55 by peda-cos         ###   ########.fr       */
+/*   Updated: 2025/03/29 15:16:51 by peda-cos         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -25,18 +25,15 @@ int	main(int argc, char **argv, char **envp)
 	(void)argv;
 	last_exit = 0;
 	env = copy_env(envp);
-	signal(SIGINT, signal_handler);
-	signal(SIGQUIT, SIG_IGN);
+	setup_interactive_signals();
 	while (1)
 	{
 		input = readline("minishell$ ");
-		if (!input)
-		{
-			printf("exit\n");
+		if (handle_eof(input))
 			break ;
-		}
 		if (*input)
 			add_history(input);
+		g_signal_received = 0;
 		tokens = tokenize_input(input);
 		if (tokens)
 		{
@@ -58,7 +55,9 @@ int	main(int argc, char **argv, char **envp)
 				else
 				{
 					saved_stdin = dup(STDIN_FILENO);
+					setup_execution_signals();
 					execute_command(cmd, env, &last_exit);
+					setup_interactive_signals();
 					dup2(saved_stdin, STDIN_FILENO);
 					close(saved_stdin);
 					free_commands(cmd);
@@ -69,5 +68,5 @@ int	main(int argc, char **argv, char **envp)
 		free(input);
 	}
 	free_env(env);
-	return (0);
+	return (last_exit);
 }


### PR DESCRIPTION
### Implementação do Tratamento de Sinais no Minishell

**Descrição:**
Este PR adiciona tratamento avançado de sinais (SIGINT e SIGQUIT) no minishell, diferenciando claramente os modos interativo (prompt) e de execução de comandos.

**Principais alterações:**
- **signals.h**: Definição das funções para configuração e reinicialização dos sinais.
- **handler/main.c**: Implementação dos handlers específicos para os modos interativo e execução, além de função para resetar sinais ao comportamento padrão.
- **executor/process.c**: Reseta os sinais no processo filho durante a execução de comandos externos.
- **sources/main.c**: Integração dos setups específicos antes e após execução de comandos.
- **includes/minishell.h**: Inclusão do novo header de sinais.

**Como testar:**
- Executar comandos internos e externos e verificar comportamento correto ao enviar Ctrl+C (SIGINT) e Ctrl+\ (SIGQUIT).
- Garantir que o prompt interativo volte corretamente após interrupções de comandos.
- Testar Ctrl+D para garantir que o shell encerre adequadamente.

**Issues relacionadas:**
Nenhuma.