### PR TITLE
Refactor/valgrind

### DIFF
--- a/includes/macros.h
+++ b/includes/macros.h
@@ -6,7 +6,7 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/19 19:15:26 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/03/22 22:09:55 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/03/27 22:42:20 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,7 +16,7 @@
 # define TRUE	1
 # define FALSE	0
 
-// Tokenizer Defines
+/* Tokenizer ------------ */
 # define PIPE_CHR	'|'
 # define BACKSLASH_CHR	'\\'
 # define DOT_AND_COMA_CHR	';'
@@ -24,12 +24,11 @@
 # define REDIRECT_OUT_CHR	'>'
 # define SINGLE_QUOTE_CHR	'\''
 # define DOUBLE_QUOTE_CHR	'"'
-
-/* Strings Defines */
 # define PIPE_STR "|"
 # define APPEND_STR ">>"
 # define HEREDOC_STR "<<"
 # define REDIRECT_IN_STR "<"
 # define REDIRECT_OUT_STR ">"
+/* ----------------------- */
 
 #endif

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -56,15 +56,8 @@ void		free_commands(t_command *cmd);
 /* 			Utility for variable expansion */
 char		*expand_variables(char *str, char **env, int last_exit);
 
-/* 			Tokenizer: splits input into tokens 
+/* 			Tokenizer: splits input into tokens
 			(handling quotes and special symbols) */
-int			is_metachar(char c);
 t_token		*tokenize_input(char *input);
-void		add_token(t_token **tokens, t_token *new);
-t_token		*new_token(char *value, t_token_type type);
-int			is_quote_delimiter(char *str, int *index, char delimiter);
-void		add_word_in_quotes(t_token **tokens, char *str, int *index);
-void		add_word_with_quotes(t_token **tokens, char *str, int *index);
-void		add_word_without_quotes(t_token **tokens, char *str, int *index);
 
 #endif

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -35,7 +35,8 @@ void		free_env(char **env);
 t_command	*parse_tokens(t_token *tokens, char **env, int last_exit);
 
 /* 			Executor: executes a command chain (with redirections/pipes) */
-void		execute_command(t_command *cmd, char **env, int *last_exit);
+void		execute_command(t_command *cmd, char **env, int *last_exit,
+						t_token *tokens);
 
 /*			Builtin commands */
 int			builtin_pwd(void);

--- a/sources/builtin/builtin.h
+++ b/sources/builtin/builtin.h
@@ -6,7 +6,7 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/25 14:15:36 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/03/29 20:10:43 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/03/29 20:12:06 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,6 +14,8 @@
 # define BUILTIN_H
 
 # include "minishell.h"
+
+# define UNSET_NO_ARGS_ERR	"unset: not enough arguments"
 
 /* Environment management */
 char	**copy_env(char **envp);

--- a/sources/builtin/builtin.h
+++ b/sources/builtin/builtin.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   builtin.h                                          :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: peda-cos <peda-cos@student.42sp.org.br>    +#+  +:+       +#+        */
+/*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/25 14:15:36 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/03/25 14:32:25 by peda-cos         ###   ########.fr       */
+/*   Updated: 2025/03/29 20:10:43 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,7 +17,7 @@
 
 /* Environment management */
 char	**copy_env(char **envp);
-int		find_env_index(const char *key, char **env);
+int		find_env_index(char *key, char **env);
 
 /* Builtin commands */
 int		builtin_echo(char **args, int *last_exit);

--- a/sources/builtin/cd_pwd.c
+++ b/sources/builtin/cd_pwd.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   cd_pwd.c                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: peda-cos <peda-cos@student.42sp.org.br>    +#+  +:+       +#+        */
+/*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/25 14:20:28 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/03/25 14:32:28 by peda-cos         ###   ########.fr       */
+/*   Updated: 2025/03/29 19:58:43 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,6 +14,8 @@
 
 int	builtin_cd(char **args)
 {
+	if (!args)
+		return (1);
 	if (!args[1])
 	{
 		ft_putstr_fd("cd: missing argument\n", STDERR_FILENO);

--- a/sources/builtin/echo.c
+++ b/sources/builtin/echo.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   echo.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: peda-cos <peda-cos@student.42sp.org.br>    +#+  +:+       +#+        */
+/*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/25 14:20:01 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/03/25 14:27:35 by peda-cos         ###   ########.fr       */
+/*   Updated: 2025/03/29 20:06:34 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -50,6 +50,8 @@ int	builtin_echo(char **args, int *last_exit)
 	int	newline;
 
 	(void)last_exit;
+	if (!args || !*args)
+		return (1);
 	i = 1;
 	newline = 1;
 	while (args[i] && is_valid_n_option(args[i]))

--- a/sources/builtin/exit.c
+++ b/sources/builtin/exit.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   exit.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: peda-cos <peda-cos@student.42sp.org.br>    +#+  +:+       +#+        */
+/*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/25 14:21:26 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/03/25 14:27:57 by peda-cos         ###   ########.fr       */
+/*   Updated: 2025/03/30 00:58:08 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,8 +19,7 @@ int	builtin_exit(char **args)
 	exit_code = 0;
 	if (args[1])
 		exit_code = ft_atoi(args[1]);
-	exit(exit_code);
-	return (0);
+	return (exit_code);
 }
 
 int	is_parent_builtin(char *cmd)

--- a/sources/builtin/export.c
+++ b/sources/builtin/export.c
@@ -6,7 +6,7 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/25 14:20:51 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/03/29 20:08:20 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/03/29 20:20:02 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -60,12 +60,20 @@ static int	add_new_entry(char ***env, char *new_entry)
 static int	process_export_arg(char ***env, char *arg)
 {
 	int		idx;
+	char	*arg_key;
 	char	*new_entry;
+	char	*equal_chr_ptr;
 
 	new_entry = ft_strdup(arg);
 	if (!new_entry)
 		return (1);
-	idx = find_env_index(arg, *env);
+	equal_chr_ptr = ft_strchr(arg, '=');
+	if (equal_chr_ptr)
+		arg_key = ft_substr(arg, 0, equal_chr_ptr - arg);
+	else
+		arg_key = ft_strdup(arg);
+	idx = find_env_index(arg_key, *env);
+	free(arg_key);
 	if (idx >= 0)
 		return (update_existing_entry(env, new_entry, idx));
 	else

--- a/sources/builtin/export.c
+++ b/sources/builtin/export.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   export.c                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: peda-cos <peda-cos@student.42sp.org.br>    +#+  +:+       +#+        */
+/*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/25 14:20:51 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/03/25 14:28:14 by peda-cos         ###   ########.fr       */
+/*   Updated: 2025/03/29 20:08:20 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -77,7 +77,7 @@ int	builtin_export(char **args, char ***env)
 	int	i;
 	int	status;
 
-	if (!*env)
+	if (! env || !*env || !args || !*args)
 		return (1);
 	if (!args[1])
 		return (display_environment(*env));

--- a/sources/builtin/main.c
+++ b/sources/builtin/main.c
@@ -3,21 +3,25 @@
 /*                                                        :::      ::::::::   */
 /*   main.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: peda-cos <peda-cos@student.42sp.org.br>    +#+  +:+       +#+        */
+/*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/26 15:22:32 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/03/25 14:32:18 by peda-cos         ###   ########.fr       */
+/*   Updated: 2025/03/29 20:05:54 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "builtin.h"
 
+// TODO: Faz sentido ficar aqui se apenas é utilizado em sources/main.c?
+// Nao deveria ser um método static do arquivo main.c?
 char	**copy_env(char **envp)
 {
-	char	**env;
 	int		i;
 	int		count;
+	char	**env;
 
+	if (!envp || !*envp)
+		return (NULL);
 	count = 0;
 	while (envp[count])
 		count++;
@@ -34,22 +38,35 @@ char	**copy_env(char **envp)
 	return (env);
 }
 
-int	find_env_index(const char *key, char **env)
+// TODO: faz sentido esse método ficar aqui??
+// Não deveria ser um método em arquivo utils.c 
+// ja que é usado pelo builtin export
+int	find_env_index(char *key, char **env)
 {
-	int	i;
-	int	key_len;
+	int		i;
+	char	*env_key;
+	char	*equal_chr_ptr;
 
 	i = 0;
-	key_len = ft_strlen(key);
-	while (env && env[i])
+	if (!key || !env)
+		return (-1);
+	while (env[i])
 	{
-		if (!ft_strncmp(env[i], key, key_len) && env[i][key_len] == '=')
+		equal_chr_ptr = ft_strchr(env[i], '=');
+		env_key = ft_substr(env[i], 0, equal_chr_ptr - env[i]);
+		if (ft_strcmp(key, env_key) == 0)
+		{
+			free(env_key);
 			return (i);
+		}
+		free(env_key);
 		i++;
 	}
 	return (-1);
 }
 
+// TODO: faz sentido o nome desse arquivo ser main.c?
+// Nao deveria ser env.c? ja que fornece um dos builtins necessários!
 int	builtin_env(char **env)
 {
 	int	i;

--- a/sources/builtin/unset.c
+++ b/sources/builtin/unset.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   unset.c                                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: peda-cos <peda-cos@student.42sp.org.br>    +#+  +:+       +#+        */
+/*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/25 14:18:12 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/03/25 14:28:30 by peda-cos         ###   ########.fr       */
+/*   Updated: 2025/03/29 20:09:20 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -27,6 +27,8 @@ int	builtin_unset(char **args, char ***env)
 	int	idx;
 	int	i;
 
+	if (!args || !*args || !env || !*env)
+		return (1);
 	if (!args[1])
 		return (0);
 	i = 1;

--- a/sources/builtin/unset.c
+++ b/sources/builtin/unset.c
@@ -30,7 +30,10 @@ int	builtin_unset(char **args, char ***env)
 	if (!args || !*args || !env || !*env)
 		return (1);
 	if (!args[1])
-		return (0);
+	{
+		ft_putendl_fd(UNSET_NO_ARGS_ERR, STDERR_FILENO);
+		return (1);
+	}
 	i = 1;
 	while (args[i])
 	{

--- a/sources/executor/executor.h
+++ b/sources/executor/executor.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   executor.h                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: peda-cos <peda-cos@student.42sp.org.br>    +#+  +:+       +#+        */
+/*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/25 08:11:28 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/03/25 08:25:40 by peda-cos         ###   ########.fr       */
+/*   Updated: 2025/03/30 00:49:46 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,6 +14,16 @@
 # define EXECUTOR_H
 
 # include "minishell.h"
+
+typedef struct s_process_command_args
+{
+	int		pid;
+	char **env;
+	t_command	*cmd;
+	int		pipefd[2];
+	int		*last_exit;
+	t_token	*tokens;
+}	t_process_command_args;
 
 /*
 ** Path finding and manipulation functions (path_utils.c)
@@ -43,10 +53,9 @@ int		execute_external(t_command *cmd, char **env);
 ** Process management functions (process.c)
 */
 int		setup_pipe(t_command *cmd, int pipefd[2]);
-void	child_process(t_command *cmd, int pipefd[2], char **env,
-			int *last_exit);
-void	parent_process(t_command *cmd, int pipefd[2], pid_t pid,
-			int *last_exit);
-int		process_command(t_command *cmd, char **env, int *last_exit);
+void	child_process(t_process_command_args *param);
+void	parent_process(t_process_command_args *param);
+int	process_command(t_command *cmd,
+			char **env, int *last_exit, t_token	*tokens);
 
 #endif

--- a/sources/executor/main.c
+++ b/sources/executor/main.c
@@ -3,16 +3,17 @@
 /*                                                        :::      ::::::::   */
 /*   main.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: peda-cos <peda-cos@student.42sp.org.br>    +#+  +:+       +#+        */
+/*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/26 15:01:28 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/03/25 08:25:40 by peda-cos         ###   ########.fr       */
+/*   Updated: 2025/03/30 02:06:40 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "executor.h"
 
-void	execute_command(t_command *cmd, char **env, int *last_exit)
+void	execute_command(t_command *cmd,
+	char **env, int *last_exit, t_token	*tokens)
 {
 	int	stdin_backup;
 	int	result;
@@ -27,7 +28,7 @@ void	execute_command(t_command *cmd, char **env, int *last_exit)
 	}
 	while (cmd)
 	{
-		result = process_command(cmd, env, last_exit);
+		result = process_command(cmd, env, last_exit, tokens);
 		if (result < 0)
 			break ;
 		cmd = cmd->next;

--- a/sources/executor/process.c
+++ b/sources/executor/process.c
@@ -3,14 +3,22 @@
 /*                                                        :::      ::::::::   */
 /*   process.c                                          :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: peda-cos <peda-cos@student.42sp.org.br>    +#+  +:+       +#+        */
+/*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/25 08:19:21 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/03/29 15:15:49 by peda-cos         ###   ########.fr       */
+/*   Updated: 2025/03/30 02:07:26 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "executor.h"
+
+static void exit_child_process(int signal, t_process_command_args *param)
+{
+	free_env(param->env);
+	free_commands(param->cmd);
+	free_tokens(param->tokens);
+	exit(signal);
+}
 
 int	setup_pipe(t_command *cmd, int pipefd[2])
 {
@@ -32,60 +40,69 @@ int	setup_pipe(t_command *cmd, int pipefd[2])
 	return (0);
 }
 
-void	child_process(t_command *cmd, int pipefd[2], char **env, int *last_exit)
+void	child_process(t_process_command_args *param) 
 {
-	if (!cmd || !env || !last_exit)
-		exit(1);
+	if (!param->cmd || !param->env || !(param->last_exit))
+	exit_child_process(1, param);
 	reset_signals();
-	if (cmd->next && pipefd[1] > 0)
+	if (param->cmd->next && param->pipefd[1] > 0)
 	{
-		dup2(pipefd[1], STDOUT_FILENO);
-		close(pipefd[0]);
-		close(pipefd[1]);
+		dup2(param->pipefd[1], STDOUT_FILENO);
+		close(param->pipefd[0]);
+		close(param->pipefd[1]);
 	}
-	if (setup_input_redirection(cmd) < 0 || setup_output_redirection(cmd) < 0)
-		exit(1);
-	if (cmd->argc <= 0)
-		exit(0);
-	if (is_builtin(cmd->args[0]))
-		exit(execute_builtin(cmd, &env, last_exit));
-	exit(execute_external(cmd, env));
+	if (setup_input_redirection(param->cmd) < 0 
+		|| setup_output_redirection(param->cmd) < 0)
+	exit_child_process(1, param);
+	if (param->cmd->argc <= 0)
+	exit_child_process(0, param);
+	if (is_builtin(param->cmd->args[0]))
+		exit_child_process(execute_builtin(
+			param->cmd, &param->env, (param->last_exit)), param);
+	exit_child_process(execute_external(
+		param->cmd, param->env), param);
 }
 
-void	parent_process(t_command *cmd, int pipefd[2], pid_t pid, int *last_exit)
+void	parent_process(t_process_command_args *param)
 {
 	int	status;
 
-	if (!cmd || !last_exit)
-		return ;
-	if (cmd->next && pipefd[0] > 0)
+	if (!param->cmd || !(param->last_exit))
+	return ;
+	if (param->cmd->next && param->pipefd[0] > 0)
 	{
-		close(pipefd[1]);
-		dup2(pipefd[0], STDIN_FILENO);
-		close(pipefd[0]);
+		close(param->pipefd[1]);
+		dup2(param->pipefd[0], STDIN_FILENO);
+		close(param->pipefd[0]);
 	}
-	waitpid(pid, &status, 0);
-	*last_exit = WEXITSTATUS(status);
+	waitpid(param->pid, &status, 0);
+	*(param->last_exit) = WEXITSTATUS(status);
 }
 
-int	process_command(t_command *cmd, char **env, int *last_exit)
+int	process_command(t_command *cmd,
+	char **env, int *last_exit, t_token	*tokens)
 {
 	int		pipefd[2];
 	pid_t	pid;
+	t_process_command_args	args;
 
 	if (!cmd || !env || !last_exit)
 		return (-1);
 	if (setup_pipe(cmd, pipefd) < 0)
 		return (-1);
 	pid = fork();
+	args.cmd	= cmd;
+	args.env	= env;
+	args.pid	= pid;
+	args.tokens	= tokens;
+	args.last_exit	= last_exit;
+	args.pipefd[0]	= pipefd[0];
+	args.pipefd[1]	= pipefd[1];
 	if (pid < 0)
-	{
-		perror("fork");
-		return (-1);
-	}
+		return (perror("fork"), -1);
 	else if (pid == 0)
-		child_process(cmd, pipefd, env, last_exit);
+		child_process(&args);
 	else
-		parent_process(cmd, pipefd, pid, last_exit);
+		parent_process(&args);
 	return (0);
 }

--- a/sources/main.c
+++ b/sources/main.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   main.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: peda-cos <peda-cos@student.42sp.org.br>    +#+  +:+       +#+        */
+/*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/19 19:05:27 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/03/29 15:16:51 by peda-cos         ###   ########.fr       */
+/*   Updated: 2025/03/30 02:03:35 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -56,7 +56,7 @@ int	main(int argc, char **argv, char **envp)
 				{
 					saved_stdin = dup(STDIN_FILENO);
 					setup_execution_signals();
-					execute_command(cmd, env, &last_exit);
+					execute_command(cmd, env, &last_exit, tokens);
 					setup_interactive_signals();
 					dup2(saved_stdin, STDIN_FILENO);
 					close(saved_stdin);

--- a/sources/tokenizer/main.c
+++ b/sources/tokenizer/main.c
@@ -6,7 +6,7 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/22 13:18:28 by jlacerda          #+#    #+#             */
-/*   Updated: 2025/03/22 22:09:55 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/03/27 22:46:04 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -30,7 +30,7 @@ static int	process_quoted_word(
 	return (word_index);
 }
 
-void	add_token_word(char *str, int *index, t_token **tokens)
+static void	add_token_word(char *str, int *index, t_token **tokens)
 {
 	char	*word;
 	int		word_index;
@@ -91,11 +91,12 @@ static void	add_token_meta(char *input, int *index, t_token **tokens)
 t_token	*tokenize_input(char *input)
 {
 	int		index;
-	int		is_metachar;
 	t_token	*tokens;
 
 	index = 0;
 	tokens = NULL;
+	if (!input)
+		return (NULL);
 	while (input[index])
 	{
 		if (input[index] == DOT_AND_COMA_CHR)
@@ -105,10 +106,9 @@ t_token	*tokenize_input(char *input)
 			index++;
 			continue ;
 		}
-		is_metachar = (input[index] == PIPE_CHR
-				|| input[index] == REDIRECT_IN_CHR
-				|| input[index] == REDIRECT_OUT_CHR);
-		if (is_metachar)
+		if (input[index] == PIPE_CHR
+			|| input[index] == REDIRECT_IN_CHR
+			|| input[index] == REDIRECT_OUT_CHR)
 			add_token_meta(input, &index, &tokens);
 		else
 			add_token_word(input, &index, &tokens);

--- a/sources/tokenizer/main.c
+++ b/sources/tokenizer/main.c
@@ -6,11 +6,11 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/22 13:18:28 by jlacerda          #+#    #+#             */
-/*   Updated: 2025/03/27 22:46:04 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/03/29 19:47:17 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "minishell.h"
+#include "tokenizer.h"
 
 static int	process_quoted_word(
 	char *str, char *word, int *index, char delimiter)

--- a/sources/tokenizer/tokenizer.h
+++ b/sources/tokenizer/tokenizer.h
@@ -1,0 +1,23 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   tokenizer.h                                        :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/03/27 22:31:37 by jlacerda          #+#    #+#             */
+/*   Updated: 2025/03/27 22:35:53 by jlacerda         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#ifndef TOKENIZER_H
+# define TOKENIZER_H
+
+# include "minishell.h"
+
+int		is_metachar(char c);
+void	add_token(t_token **tokens, t_token *new);
+t_token	*new_token(char *value, t_token_type type);
+int		is_quote_delimiter(char *str, int *index, char delimiter);
+
+#endif

--- a/sources/tokenizer/utils.c
+++ b/sources/tokenizer/utils.c
@@ -6,11 +6,11 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/22 13:18:28 by jlacerda          #+#    #+#             */
-/*   Updated: 2025/03/22 22:09:55 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/03/29 19:47:25 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "minishell.h"
+#include "tokenizer.h"
 
 t_token	*new_token(char *value, t_token_type type)
 {

--- a/sources/utils.c
+++ b/sources/utils.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   utils.c                                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: peda-cos <peda-cos@student.42sp.org.br>    +#+  +:+       +#+        */
+/*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/26 14:54:34 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/02/27 08:34:24 by peda-cos         ###   ########.fr       */
+/*   Updated: 2025/03/30 02:04:18 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -49,26 +49,21 @@ void	free_commands(t_command *cmd)
 		return ;
 	while (cmd)
 	{
-		if (cmd->args)
+		i = 0;
+		while (cmd->args[i])
 		{
-			i = 0;
-			while (cmd->args[i])
-			{
-				free(cmd->args[i]);
-				i++;
-			}
-			free(cmd->args);
+			free(cmd->args[i]);
+			i++;
 		}
-		if (cmd->input_file)
-			free(cmd->input_file);
-		if (cmd->output_file)
-			free(cmd->output_file);
-		if (cmd->heredoc_delim)
-			free(cmd->heredoc_delim);
+		free(cmd->args);
+		free(cmd->input_file);
+		free(cmd->output_file);
+		free(cmd->heredoc_delim);
 		tmp = cmd;
 		cmd = cmd->next;
 		free(tmp);
 	}
+	free(cmd);
 }
 
 char	*expand_variables(char *str, char **env, int last_exit)


### PR DESCRIPTION
### Alterações conforme execução isolada com Valgrind 

**Descrição:**

Este PR adiciona alterações conforme validações das funcionalidades de forma isolada, apenas dentro da pasta de seu próprio contexto, implementando uma função `main` compilados junto dos arquivos `.c` da pasta. Por exemplo, navegando para dentro de `sources/builtin`

Além de aplicar correções necessárias conforme as validações.

> `cc -I . -I ../../includes -I ../../libft -g *.c ../../libft/libft.a`
> `valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes ./a.out`

**Principais alterações:**
- **builtins**: adicionado validação de parâmetros recebidos como null
- **export** e **unset**: corrige lógica de obtenção do indíce de uma variável
- **export**: adiciona garantia de processamento do nome da chave do argumento (sem o seu valor)
- **executor**: adiciona liberação de memória durante execução de comando (incluindo fork de processo)
