### PR TITLE
Aprimoramento do Tratamento de Redirecionamento de Arquivos no Parser && Aprimoramento de Tratamento de Processos e Validação de Tokens

### DIFF
--- a/sources/executor/process.c
+++ b/sources/executor/process.c
@@ -6,27 +6,54 @@
 /*   By: peda-cos <peda-cos@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/25 08:19:21 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/04/13 09:23:58 by peda-cos         ###   ########.fr       */
+/*   Updated: 2025/04/14 11:57:13 by peda-cos         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "executor.h"
+
+static int	setup_child_io(t_command *cmd, int pipefd[2])
+{
+	if (cmd->next && pipefd[1] > 0)
+	{
+		dup2(pipefd[1], STDOUT_FILENO);
+		close(pipefd[0]);
+		close(pipefd[1]);
+	}
+	if (setup_input_redirection(cmd) < 0 || setup_output_redirection(cmd) < 0)
+		return (-1);
+	return (0);
+}
+
+static int	handle_empty_command(t_command *cmd)
+{
+	char	buffer[4096];
+	ssize_t	bytes_read;
+
+	if (cmd->argc <= 0)
+	{
+		if (cmd->output_file != NULL)
+		{
+			bytes_read = read(STDIN_FILENO, buffer, sizeof(buffer));
+			while (bytes_read > 0)
+			{
+				write(STDOUT_FILENO, buffer, bytes_read);
+				bytes_read = read(STDIN_FILENO, buffer, sizeof(buffer));
+			}
+		}
+		return (1);
+	}
+	return (0);
+}
 
 void	child_process(t_process_command_args *param)
 {
 	if (!param->cmd || !param->env || !(param->last_exit))
 		exit_free(1, param->env, param->cmd, param->tokens);
 	reset_signals();
-	if (param->cmd->next && param->pipefd[1] > 0)
-	{
-		dup2(param->pipefd[1], STDOUT_FILENO);
-		close(param->pipefd[0]);
-		close(param->pipefd[1]);
-	}
-	if (setup_input_redirection(param->cmd) < 0
-		|| setup_output_redirection(param->cmd) < 0)
+	if (setup_child_io(param->cmd, param->pipefd) < 0)
 		exit_free(1, param->env, param->cmd, param->tokens);
-	if (param->cmd->argc <= 0)
+	if (handle_empty_command(param->cmd))
 		exit_free(0, param->env, param->cmd, param->tokens);
 	if (is_builtin(param->cmd->args[0]))
 		exit_free(execute_builtin(param->cmd, &param->env, param->last_exit),

--- a/sources/parser/main.c
+++ b/sources/parser/main.c
@@ -6,7 +6,7 @@
 /*   By: peda-cos <peda-cos@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/26 14:40:39 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/03/25 01:51:38 by peda-cos         ###   ########.fr       */
+/*   Updated: 2025/04/14 02:07:45 by peda-cos         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -37,9 +37,30 @@ static void	set_redirection_target(t_command *cmd, t_token *token,
 		cmd->heredoc_delim = ft_strdup(target->value);
 }
 
+static int	create_output_file(char *filename, int append)
+{
+	int	flags;
+	int	fd;
+
+	flags = O_WRONLY | O_CREAT;
+	if (append)
+		flags |= O_APPEND;
+	else
+		flags |= O_TRUNC;
+	fd = open(filename, flags, 0644);
+	if (fd < 0)
+	{
+		perror(filename);
+		return (0);
+	}
+	close(fd);
+	return (1);
+}
+
 static int	handle_redirection(t_command *cmd, t_token **token_ptr)
 {
 	t_token	*token;
+	int		result;
 
 	token = *token_ptr;
 	*token_ptr = token->next;
@@ -48,6 +69,12 @@ static int	handle_redirection(t_command *cmd, t_token **token_ptr)
 		ft_putstr_fd("minishell: syntax error near unexpected token\n",
 			STDERR_FILENO);
 		return (0);
+	}
+	if (token->type == REDIRECT_OUT || token->type == APPEND)
+	{
+		result = create_output_file((*token_ptr)->value, token->type == APPEND);
+		if (!result)
+			return (0);
 	}
 	set_redirection_target(cmd, token, *token_ptr);
 	*token_ptr = (*token_ptr)->next;

--- a/sources/validator/utils.c
+++ b/sources/validator/utils.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   utils.c                                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
+/*   By: peda-cos <peda-cos@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/05 17:03:12 by jlacerda          #+#    #+#             */
-/*   Updated: 2025/04/05 19:45:16 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/04/14 11:55:25 by peda-cos         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,10 +14,8 @@
 
 int	is_redirection(t_token *token)
 {
-	return (token->type == REDIRECT_IN
-		|| token->type == REDIRECT_OUT
-		|| token->type == HEREDOC
-		|| token->type == APPEND);
+	return (token->type == REDIRECT_IN || token->type == REDIRECT_OUT
+		|| token->type == HEREDOC || token->type == APPEND);
 }
 
 int	is_pipe(t_token *token)
@@ -38,7 +36,10 @@ int	is_valid_pipe_position(t_token *token)
 {
 	if (!token->prev || !token->next)
 		return (FALSE);
-	if (token->prev->type != WORD || token->next->type != WORD)
+	if (token->prev->type != WORD)
+		return (FALSE);
+	if (token->next->type != WORD && !(is_redirection(token->next)
+			&& token->next->next && token->next->next->type == WORD))
 		return (FALSE);
 	return (TRUE);
 }


### PR DESCRIPTION
## Descrição
Este pull request adiciona melhorias significativas no tratamento de redirecionamento de arquivos no parser do Minishell, focando em:
- Verificação de criação de arquivos antes do redirecionamento
- Suporte robusto para redirecionamento de saída padrão
- Tratamento de erros durante criação de arquivos

## Motivação
- Aumentar a resiliência do parser
- Prevenir falhas silenciosas de redirecionamento
- Fornecer feedback adequado em caso de erros de criação de arquivos

## Modificações Principais
- Nova função `create_output_file()` 
- Pré-verificação de criação de arquivos
- Suporte a redirecionamento com append
- Tratamento de erros com `perror()`

## Detalhes Técnicos
- Flags de criação de arquivo: 
  - `O_WRONLY`
  - `O_CREAT`
  - `O_APPEND` (opcional)
  - `O_TRUNC` (padrão)
- Permissões de arquivo: 0644