### PR TITLE
Atualiza validaçoes de problemas

### DIFF
--- a/sources/executor/command_utils.c
+++ b/sources/executor/command_utils.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   command_utils.c                                    :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: peda-cos <peda-cos@student.42sp.org.br>    +#+  +:+       +#+        */
+/*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/25 08:12:34 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/04/13 14:53:09 by peda-cos         ###   ########.fr       */
+/*   Updated: 2025/04/18 15:48:59 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -55,7 +55,8 @@ static int	is_valid_executable(char *path)
 	if (stat(path, &path_stat) != 0)
 	{
 		err_stat = ft_strjoin("minishell: ", path);
-		perror(err_stat);
+		ft_putstr_fd(err_stat, STDERR_FILENO);
+		ft_putendl_fd(": No such file or directory", STDERR_FILENO);
 		free(err_stat);
 		return (FALSE);
 	}

--- a/sources/tokenizer/main.c
+++ b/sources/tokenizer/main.c
@@ -6,7 +6,7 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/22 13:18:28 by jlacerda          #+#    #+#             */
-/*   Updated: 2025/04/12 22:40:35 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/04/18 15:27:01 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -25,7 +25,7 @@ t_token	*tokenize_input(char *input)
 	{
 		if (input[index] == DOT_AND_COMA_CHR)
 			break ;
-		if (ft_isspace(input[index]))
+		if (ft_isspace(input[index]) || input[index] == BACKSLASH_CHR)
 		{
 			index++;
 			continue ;

--- a/sources/tokenizer/token.c
+++ b/sources/tokenizer/token.c
@@ -6,7 +6,7 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/22 13:18:28 by jlacerda          #+#    #+#             */
-/*   Updated: 2025/04/15 00:55:38 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/04/18 15:33:14 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,7 +18,7 @@ t_token	*new_token(t_token_content *content, t_token_type type)
 	t_token_content	*tmp_content;
 
 	token = malloc(sizeof(t_token));
-	if (!token)
+	if (!token ||	!content)
 		return (NULL);
 	token->length = 0;
 	token->prev = NULL;

--- a/sources/tokenizer/word.c
+++ b/sources/tokenizer/word.c
@@ -6,7 +6,7 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/22 13:18:28 by jlacerda          #+#    #+#             */
-/*   Updated: 2025/04/15 00:52:56 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/04/18 15:35:48 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -118,4 +118,3 @@ void	add_token_word(char *str, int *index, t_token **tokens)
 	content = add_only_content_word(content, &param);
 	add_token(tokens, new_token(content, WORD));
 }
-// Precisa validar se content existe ?

--- a/sources/validator/main.c
+++ b/sources/validator/main.c
@@ -6,7 +6,7 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/05 17:03:12 by jlacerda          #+#    #+#             */
-/*   Updated: 2025/04/16 20:01:17 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/04/18 14:52:48 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,6 +14,7 @@
 
 static int	print_syntax_error(char *token_value)
 {
+	ft_putstr_fd("minishell: ", STDERR_FILENO);
 	ft_putstr_fd(INVALID_TOKEN_MSG_ERR, STDERR_FILENO);
 	ft_putstr_fd(token_value, STDERR_FILENO);
 	ft_putendl_fd("'", STDERR_FILENO);

--- a/sources/validator/main.c
+++ b/sources/validator/main.c
@@ -6,7 +6,7 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/05 17:03:12 by jlacerda          #+#    #+#             */
-/*   Updated: 2025/04/15 00:24:11 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/04/16 20:01:17 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -27,11 +27,9 @@ int	validate_tokens(t_token **tokens)
 	token = *tokens;
 	while (token)
 	{
-		if (is_invalid_token(token))
-			return (print_syntax_error(token->content->value));
 		if (is_pipe(token) && !is_valid_pipe_position(token))
 			return (print_syntax_error(token->content->value));
-		if (is_redirection(token) && !is_valid_redirection(token))
+		if (is_redirection(token->type) && !is_valid_redirection(token))
 			return (print_syntax_error(token->content->value));
 		token = token->next;
 	}

--- a/sources/validator/utils.c
+++ b/sources/validator/utils.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   utils.c                                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: peda-cos <peda-cos@student.42sp.org.br>    +#+  +:+       +#+        */
+/*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/05 17:03:12 by jlacerda          #+#    #+#             */
-/*   Updated: 2025/04/14 22:39:19 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/04/16 20:02:14 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,26 +17,13 @@ int	is_pipe(t_token *token)
 	return (token->type == PIPE);
 }
 
-int	is_invalid_token(t_token *token)
-{
-	int	is_empty_or_null;
-
-	is_empty_or_null = !token->content->value
-		|| strlen(token->content->value) == 0;
-	if (token->type == WORD && is_empty_or_null)
-		return (TRUE);
-	if (is_pipe(token) && (!token->prev || !token->next))
-		return (TRUE);
-	return (FALSE);
-}
-
 int	is_valid_pipe_position(t_token *token)
 {
 	if (!token->prev || !token->next)
 		return (FALSE);
 	if (token->prev->type != WORD)
 		return (FALSE);
-	if (token->next->type != WORD && !(is_redirection(token->next)
+	if (token->next->type != WORD && !(is_redirection(token->next->type)
 			&& token->next->next && token->next->next->type == WORD))
 		return (FALSE);
 	return (TRUE);

--- a/sources/validator/validator.h
+++ b/sources/validator/validator.h
@@ -6,7 +6,7 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/31 14:20:01 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/04/15 02:25:51 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/04/16 19:53:16 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,8 +18,7 @@
 # define INVALID_TOKEN_MSG_ERR	"Erro de sintaxe próximo ao token inesperado `"
 
 int	is_pipe(t_token *token);
-int	is_redirection(t_token *token);
-int	is_invalid_token(t_token *token);
+int	is_redirection(t_token_type type);
 int	is_valid_redirection(t_token *token);
 int	is_valid_pipe_position(t_token *token);
 

--- a/sources/validator/validator.h
+++ b/sources/validator/validator.h
@@ -6,7 +6,7 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/31 14:20:01 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/04/16 19:53:16 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/04/18 14:47:45 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,7 +15,7 @@
 
 # include "minishell.h"
 
-# define INVALID_TOKEN_MSG_ERR	"Erro de sintaxe próximo ao token inesperado `"
+# define INVALID_TOKEN_MSG_ERR	"syntax error near unexpected token `"
 
 int	is_pipe(t_token *token);
 int	is_redirection(t_token_type type);


### PR DESCRIPTION
## Descrição

Remove validação desnecessária do valor de um token.

A validação deve ocorrer nos tokens de metacaracter apenas.

A validação de verificar se um token é valido verificand seu valor, resultou em cenário estranho de processamento conforme a seguir:

```bash
➜  minishell git:(master) ✗ bash
jonnathan-ls@Dell-G15:/mnt/c/Users/jonnathan-ls/42-cursus/minishell$ ./minishell 
Minishell $ echo ""$?""
Erro de sintaxe próximo ao token inesperado `'
Minishell $
```

Com a remoção, o processamento resultou no comportamento correto:

```bash
jonnathan-ls@Dell-G15:/mnt/c/Users/jonnathan-ls/42-cursus/minishell$ ./minishell 
Minishell $ echo ""$?""
0
Minishell $
```