### PR TITLE
Implementa validação do nome de uma variável a ser exportada

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,8 @@ PARSER_SRCS = sources/parser/main.c sources/parser/utils.c
 HANDLER_SRCS = sources/handler/main.c sources/handler/utils.c
 BUILTIN_SRCS = sources/builtin/env.c sources/builtin/cd_utils.c \
 				sources/builtin/cd.c sources/builtin/echo.c \
-				sources/builtin/exit.c sources/builtin/export.c \
-				sources/builtin/pwd.c sources/builtin/unset.c
+				sources/builtin/pwd.c sources/builtin/unset.c \
+				sources/builtin/exit.c sources/builtin/export.c sources/builtin/export_utils.c
 EXECUTOR_SRCS = sources/executor/main.c sources/executor/path_utils.c \
 				sources/executor/heredoc.c sources/executor/redirection.c \
 				sources/executor/command_utils.c sources/executor/process.c \

--- a/sources/builtin/builtin.h
+++ b/sources/builtin/builtin.h
@@ -6,7 +6,7 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/25 14:15:36 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/04/15 00:56:35 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/04/18 16:42:58 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -30,6 +30,8 @@ int		builtin_exit(char **args);
 int		is_parent_builtin(char *cmd);
 
 /* Utility functions */
+int		is_valid_key(char *key);
+void	print_invalid_arg(char *arg);
 char	*get_env_value(char *key, char **env);
 void	update_env_variable(char *key, char *value, char ***env);
 

--- a/sources/builtin/export.c
+++ b/sources/builtin/export.c
@@ -6,7 +6,7 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/25 14:20:51 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/03/29 20:20:02 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/04/18 16:46:06 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -72,12 +72,18 @@ static int	process_export_arg(char ***env, char *arg)
 		arg_key = ft_substr(arg, 0, equal_chr_ptr - arg);
 	else
 		arg_key = ft_strdup(arg);
+	if (!is_valid_key(arg_key))
+	{
+		free(new_entry);
+		free(arg_key);
+		print_invalid_arg(arg);
+		return (1);
+	}
 	idx = find_env_index(arg_key, *env);
 	free(arg_key);
 	if (idx >= 0)
 		return (update_existing_entry(env, new_entry, idx));
-	else
-		return (add_new_entry(env, new_entry));
+	return (add_new_entry(env, new_entry));
 }
 
 int	builtin_export(char **args, char ***env)

--- a/sources/builtin/export_utils.c
+++ b/sources/builtin/export_utils.c
@@ -1,0 +1,33 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   export_utils.c                                     :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/04/18 16:37:32 by jlacerda          #+#    #+#             */
+/*   Updated: 2025/04/18 16:42:48 by jlacerda         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "builtin.h"
+
+void	print_invalid_arg(char *arg)
+{
+	ft_putstr_fd("Minishell: export: `", STDERR_FILENO);
+	ft_putstr_fd(arg, STDERR_FILENO);
+	ft_putendl_fd("': not a valid identifier", STDERR_FILENO);
+}
+
+int	is_valid_key(char *key)
+{
+	if (!key || !*key || !ft_isalpha(*key))
+		return (FALSE);
+	while (*key)
+	{
+		if (!ft_isalnum(*key) && *key != '_')
+			return (FALSE);
+		key++;
+	}
+	return (TRUE);
+}


### PR DESCRIPTION
## Descrição

Este PR implementa validação do nome de uma variável a ser exportada.

> Corrige Issue https://github.com/peda-cos/minishell/issues/16

## Escopo das Modificações

- Adiciona validador para conferir o nome da chave atende aos seguintes requisitos
  - alfanumérico, números, underscore, e que a primeira letra não seja um número
- Registra na saída de error padrão o argumento inválido 

## Resultado

```bash
Minishell $ export =====123
Minishell: export: `=====123': not a valid identifier
Minishell $ export ""=""
Minishell: export: `=': not a valid identifier
Minishell $ export ''=''
Minishell: export: `=': not a valid identifier
Minishell $ export =42
Minishell: export: `=42': not a valid identifier
Minishell $ export test-=42
Minishell: export: `test-=42': not a valid identifier
Minishell $ export tes-te=42
Minishell: export: `tes-te=42': not a valid identifier
Minishell $ export v.ar=42
Minishell: export: `v.ar=42': not a valid identifier
Minishell $ export v}ar=42
Minishell: export: `v}ar=42': not a valid identifier
Minishell $ export ""
Minishell: export: `': not a valid identifier
Minishell $ export $?
Minishell: export: `1': not a valid identifier
Minishell $
```