### PR TITLE
Navegação CD validando quantidade de argumentos e com `~` e `-`

### DIFF
--- a/sources/builtin/builtin.h
+++ b/sources/builtin/builtin.h
@@ -6,7 +6,7 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/25 14:15:36 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/04/15 00:56:35 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/04/19 16:52:14 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -31,6 +31,12 @@ int		is_parent_builtin(char *cmd);
 
 /* Utility functions */
 char	*get_env_value(char *key, char **env);
+
+/* CD Utility functions */
+void	update_pwd_env(char *old_pwd, char ***env);
+int		change_to_home(char ***env, char *old_pwd);
+int		change_to_previous(char ***env, char *old_pwd);
+int		change_directory(char *dir, char ***env, char *old_pwd);
 void	update_env_variable(char *key, char *value, char ***env);
 
 #endif

--- a/sources/builtin/cd.c
+++ b/sources/builtin/cd.c
@@ -6,79 +6,21 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/25 14:20:28 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/04/18 19:30:50 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/04/19 16:52:37 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "builtin.h"
 
-static void	update_pwd_env(char *old_pwd, char ***env)
+static int	exec_cd(char **args, char ***env, char *old_pwd)
 {
-	char	*new_pwd;
-
-	new_pwd = getcwd(NULL, 0);
-	if (!new_pwd)
-	{
-		perror("cd: getcwd");
-		return ;
-	}
-	update_env_variable("PWD", new_pwd, env);
-	update_env_variable("OLDPWD", old_pwd, env);
-	free(new_pwd);
-}
-
-static int	change_to_previous(char ***env, char *old_pwd)
-{
-	char	*prev_pwd;
-
-	prev_pwd = get_env_value("OLDPWD", *env);
-	if (!prev_pwd)
-	{
-		ft_putstr_fd("cd: OLDPWD not set\n", STDERR_FILENO);
-		return (1);
-	}
-	if (chdir(prev_pwd) != 0)
-	{
-		perror("cd");
-		free(prev_pwd);
-		return (1);
-	}
-	ft_putendl_fd(prev_pwd, STDOUT_FILENO);
-	update_pwd_env(old_pwd, env);
-	free(prev_pwd);
-	return (0);
-}
-
-static int	change_to_home(char ***env, char *old_pwd)
-{
-	char	*home;
-
-	home = get_env_value("HOME", *env);
-	if (!home)
-	{
-		ft_putstr_fd("cd: HOME not set\n", STDERR_FILENO);
-		return (1);
-	}
-	if (chdir(home) != 0)
-	{
-		perror("cd");
-		free(home);
-		return (1);
-	}
-	update_pwd_env(old_pwd, env);
-	free(home);
-	return (0);
-}
-
-static int	change_directory(char *dir, char ***env, char *old_pwd)
-{
-	if (chdir(dir) != 0)
-	{
-		perror("cd");
-		return (1);
-	}
-	update_pwd_env(old_pwd, env);
-	return (0);
+	if (!args[1]
+		|| ft_strcmp(args[1], "--") == 0
+		|| ft_strcmp(args[1], "~") == 0)
+		return (change_to_home(env, old_pwd));
+	else if (ft_strcmp(args[1], "-") == 0)
+		return (change_to_previous(env, old_pwd));
+	return (change_directory(args[1], env, old_pwd));
 }
 
 int	builtin_cd(char **args, char ***env)
@@ -88,20 +30,18 @@ int	builtin_cd(char **args, char ***env)
 
 	if (!args || !env || !*env)
 		return (1);
+	if (args[2] != NULL)
+	{
+		ft_putstr_fd("Minishell: cd: too many arguments\n", STDERR_FILENO);
+		return (1);
+	}
 	old_pwd = getcwd(NULL, 0);
 	if (!old_pwd)
 	{
 		perror("cd: getcwd");
 		return (1);
 	}
-	if (!args[1]
-		|| ft_strcmp(args[1], "--") == 0
-		|| ft_strcmp(args[1], "~") == 0)
-		status = change_to_home(env, old_pwd);
-	else if (ft_strcmp(args[1], "-") == 0)
-		status = change_to_previous(env, old_pwd);
-	else
-		status = change_directory(args[1], env, old_pwd);
+	status = exec_cd(args, env, old_pwd);
 	free(old_pwd);
 	return (status);
 }

--- a/sources/builtin/cd_utils.c
+++ b/sources/builtin/cd_utils.c
@@ -6,7 +6,7 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/31 21:16:04 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/04/18 19:27:42 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/04/19 16:52:25 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -35,4 +35,73 @@ void	update_env_variable(char *key, char *value, char ***env)
 		}
 		i++;
 	}
+}
+
+void	update_pwd_env(char *old_pwd, char ***env)
+{
+	char	*new_pwd;
+
+	new_pwd = getcwd(NULL, 0);
+	if (!new_pwd)
+	{
+		perror("cd: getcwd");
+		return ;
+	}
+	update_env_variable("PWD", new_pwd, env);
+	update_env_variable("OLDPWD", old_pwd, env);
+	free(new_pwd);
+}
+
+int	change_to_previous(char ***env, char *old_pwd)
+{
+	char	*prev_pwd;
+
+	prev_pwd = get_env_value("OLDPWD", *env);
+	if (!prev_pwd)
+	{
+		ft_putstr_fd("cd: OLDPWD not set\n", STDERR_FILENO);
+		return (1);
+	}
+	if (chdir(prev_pwd) != 0)
+	{
+		perror("cd");
+		free(prev_pwd);
+		return (1);
+	}
+	ft_putendl_fd(prev_pwd, STDOUT_FILENO);
+	update_pwd_env(old_pwd, env);
+	free(prev_pwd);
+	return (0);
+}
+
+int	change_to_home(char ***env, char *old_pwd)
+{
+	char	*home;
+
+	home = get_env_value("HOME", *env);
+	if (!home)
+	{
+		ft_putstr_fd("cd: HOME not set\n", STDERR_FILENO);
+		return (1);
+	}
+	if (chdir(home) != 0)
+	{
+		perror("cd");
+		free(home);
+		return (1);
+	}
+	update_pwd_env(old_pwd, env);
+	free(home);
+	return (0);
+}
+
+int	change_directory(char *dir, char ***env, char *old_pwd)
+{
+	if (chdir(dir) != 0)
+	{
+		perror("cd");
+		return (1);
+	}
+	update_pwd_env(old_pwd, env);
+	return (0);
 }

--- a/sources/builtin/cd_utils.c
+++ b/sources/builtin/cd_utils.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   cd_utils.c                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: peda-cos <peda-cos@student.42sp.org.br>    +#+  +:+       +#+        */
+/*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/31 21:16:04 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/03/31 22:13:00 by peda-cos         ###   ########.fr       */
+/*   Updated: 2025/04/18 19:27:42 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,6 +15,7 @@
 void	update_env_variable(char *key, char *value, char ***env)
 {
 	int		i;
+	char	*temp;
 	int		key_len;
 	char	*new_value;
 
@@ -25,7 +26,9 @@ void	update_env_variable(char *key, char *value, char ***env)
 		if (ft_strncmp((*env)[i], key, key_len) == 0
 			&& (*env)[i][key_len] == '=')
 		{
-			new_value = ft_strjoin(key, value);
+			temp = ft_strjoin(key, "=");
+			new_value = ft_strjoin(temp, value);
+			free(temp);
 			free((*env)[i]);
 			(*env)[i] = new_value;
 			return ;


### PR DESCRIPTION
## Descrição

Este PR implementa capacidade de navegação `cd` com `-` e `~`

> Corrige Issue https://github.com/peda-cos/minishell/issues/31 e https://github.com/peda-cos/minishell/issues/32

## Escopo das Modificações

- Adiciona método para navegar para o diretório anteriormente navegado
- Incluí navegação para `~` e `--` que muda para o diretório $HOME
- Corrige falha de atualização de variável de ambiente
- Simplifica liberação de memória do `old_pwd`
- Adiciona validação da quantidade de argumentos recebidos

## Resultado

Navegação com `~` e `-`

```bash
jonnathan-ls@Dell-G15:/mnt/c/Users/jonnathan-ls/42-cursus/minishell$ ./minishell 
Minishell $ pwd
/mnt/c/Users/jonnathan-ls/42-cursus/minishell
Minishell $ cd includes/
Minishell $ pwd
/mnt/c/Users/jonnathan-ls/42-cursus/minishell/includes
Minishell $ cd -
/mnt/c/Users/jonnathan-ls/42-cursus/minishell
Minishell $ cd -
/mnt/c/Users/jonnathan-ls/42-cursus/minishell/includes
Minishell $ cd --
Minishell $ pwd
/home/jonnathan-ls
Minishell $ cd -
/mnt/c/Users/jonnathan-ls/42-cursus/minishell/includes
Minishell $ pwd
/mnt/c/Users/jonnathan-ls/42-cursus/minishell/includes
Minishell $ cd ..
Minishell $ pwd
/mnt/c/Users/jonnathan-ls/42-cursus/minishell
Minishell $ cd ~
Minishell $ pwd
/home/jonnathan-ls
Minishell $ cd -
/mnt/c/Users/jonnathan-ls/42-cursus/minishell
Minishell $ 
```

Quantidade de argumentos maior que 1

```bash
jlacerda@c1r3p3:~/ft/minishell$ ./minishell
Minishell $ cd includes/ invalidpath
Minishell: cd: too many arguments
Minishell $ cd 1 2
Minishell: cd: too many arguments
Minishell $ echo $?
1
Minishell $ 
```