### PR TITLE
Corrige validação de argumento de string vazia e quantidade de argumentos

### DIFF
--- a/sources/builtin/exit.c
+++ b/sources/builtin/exit.c
@@ -6,7 +6,7 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/25 14:21:26 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/04/10 21:46:47 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/04/19 17:32:33 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,15 +17,17 @@ static int	is_numeric_arg(char *str)
 	int	i;
 
 	i = 0;
+	if (str[i] == '\0')
+		return (FALSE);
 	if (str[i] == '-' || str[i] == '+')
 		i++;
 	while (str[i])
 	{
 		if (!ft_isdigit(str[i]))
-			return (0);
+			return (FALSE);
 		i++;
 	}
-	return (1);
+	return (TRUE);
 }
 
 int	builtin_exit(char **args)
@@ -34,7 +36,7 @@ int	builtin_exit(char **args)
 
 	ft_putendl_fd("exit", STDOUT_FILENO);
 	exit_code = 0;
-	if (!args[1])
+	if (args[1] == NULL)
 		return (exit_code);
 	if (!is_numeric_arg(args[1]))
 	{

--- a/sources/main.c
+++ b/sources/main.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   main.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: peda-cos <peda-cos@student.42sp.org.br>    +#+  +:+       +#+        */
+/*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/19 19:05:27 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/04/12 22:57:25 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/04/19 17:30:00 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,7 +24,8 @@ static void	execute_parent_builtin(t_command *cmd, char ***env, int *last_exit,
 	else if (!ft_strcmp(cmd->args[0], "exit"))
 	{
 		*last_exit = builtin_exit(cmd->args);
-		exit_free(*last_exit, *env, cmd, tokens);
+		if (*last_exit != 1)
+			exit_free(*last_exit, *env, cmd, tokens);
 	}
 }
 


### PR DESCRIPTION
## Descrição

Este PR corrige cenário de saida do comando quando:

- **String vazia**: deve sair com registro de `numeric argument required`
- **Quantidade de argumentos**: não deve sair do terminal quando for mais de um argumento

> Corrige Issue https://github.com/peda-cos/minishell/issues/33

## Escopo das Modificações

- Modifica validação de `null` argumento deixando explicíto
- Modifica `is_numeric_arg` verificando se é uma string vazia
- Modifica `execute_parent_builtin` para somente sair do terminal, quando o retorno for diferente de (`1`) 

## Resultado

Saindo com string vazia

```bash
~/ft/minishell fix/builtin-exit ❯ bash
jlacerda@c1r3p3:~/ft/minishell$ exit ""
exit
bash: exit: : numeric argument required
~/ft/minishell fix/builtin-exit ❯ echo $?
2
~/ft/minishell fix/builtin-exit ❯ ./minishell
Minishell $ exit ""
exit
minishell: exit: : numeric argument required
~/ft/minishell fix/builtin-exit ❯ echo $?
2
```

Saindo com quantidade de argumentos maior que 1

```bash
~/ft/minishell fix/builtin-exit ❯ bash
jlacerda@c1r3p3:~/ft/minishell$ exit 1 a
exit
bash: exit: too many arguments
jlacerda@c1r3p3:~/ft/minishell$ echo $?
1
jlacerda@c1r3p3:~/ft/minishell$ exit
exit
~/ft/minishell fix/builtin-exit ❯ ./minishell
Minishell $ exit 1 a
exit
minishell: exit: too many arguments
Minishell $ echo $?
1
```