### PR TITLE
Atualiza identificação de fluxo não interativo no log do prompt e exit

### DIFF
--- a/includes/macros.h
+++ b/includes/macros.h
@@ -44,6 +44,5 @@
 # define COLOR_PASTEL_BLUE "\001\033[38;5;153m\002"
 # define COLOR_RESET "\001\033[0m\002"
 # define PROMPT_TEXT "🧙 Minishell ❯ "
-# define NO_INTERACTIVE_PROMPT_TEXT ""
 /* ----------------------- */
 #endif

--- a/includes/macros.h
+++ b/includes/macros.h
@@ -6,7 +6,7 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/19 19:15:26 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/04/20 19:22:03 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/04/20 20:11:25 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -44,5 +44,6 @@
 # define COLOR_PASTEL_BLUE "\001\033[38;5;153m\002"
 # define COLOR_RESET "\001\033[0m\002"
 # define PROMPT_TEXT "🧙 Minishell ❯ "
+# define NO_INTERACTIVE_PROMPT_TEXT ""
 /* ----------------------- */
 #endif

--- a/sources/builtin/exit.c
+++ b/sources/builtin/exit.c
@@ -34,9 +34,9 @@ int	builtin_exit(t_process_command_args	*param)
 {
 	int	exit_code;
 
-	if (param->has_fd_redirect_to_stderr)
+	if (param->has_fd_redirect_to_stderr && isatty(STDIN_FILENO))
 		ft_putendl_fd("exit", STDERR_FILENO);
-	else
+	else if (isatty(STDIN_FILENO))
 		ft_putendl_fd("exit", STDOUT_FILENO);
 	exit_code = 0;
 	if (param->cmd->args[1] == NULL)

--- a/sources/handler/utils.c
+++ b/sources/handler/utils.c
@@ -27,7 +27,8 @@ int	handle_eof(char *input)
 {
 	if (!input)
 	{
-		write(STDOUT_FILENO, "exit\n", 5);
+		if (isatty(STDIN_FILENO))
+			write(STDOUT_FILENO, "exit\n", 5);
 		return (1);
 	}
 	return (0);

--- a/sources/main.c
+++ b/sources/main.c
@@ -42,7 +42,7 @@ static char	*get_input_from_no_interactive_mode(void)
 		free(buffer);
 		return (NULL);
 	}
-	if (buffer[bytes_read - 1] == '\n')
+	if (bytes_read > 0 && buffer[bytes_read - 1] == '\n')
 		buffer[bytes_read - 1] = '\0';
 	buffer[bytes_read] = '\0';
 	return (buffer);

--- a/sources/main.c
+++ b/sources/main.c
@@ -12,6 +12,22 @@
 
 #include "minishell.h"
 
+int	is_empty_string(const char *str)
+{
+	int		i;
+
+	if (str == NULL)
+		return (FALSE);
+	i = 0;
+	while (str[i])
+	{
+		if (str[i] != ' ' && str[i] != '\t')
+			return (FALSE);
+		i++;
+	}
+	return (TRUE);
+}
+
 static char	*get_input_from_no_interactive_mode(void)
 {
 	char	*buffer;
@@ -37,8 +53,16 @@ static int	process_no_interactive_mode(char ***env)
 	char	*input;
 	int		exit_status;
 
+	exit_status = 0;
 	input = get_input_from_no_interactive_mode();
-	process_input(input, env, &exit_status);
+	if (is_empty_string(input))
+	{
+		free_env(*env);
+		free(input);
+		return (0);
+	}
+	if (input)
+		process_input(input, env, &exit_status);
 	free(input);
 	free_env(*env);
 	return (exit_status);

--- a/sources/main.c
+++ b/sources/main.c
@@ -6,7 +6,7 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/19 19:05:27 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/04/20 00:04:14 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/04/21 17:51:37 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,7 +26,10 @@ int	main(int argc, char **argv, char **envp)
 	load_history();
 	while (TRUE)
 	{
-		input = readline(get_colored_prompt());
+		if (isatty(STDIN_FILENO))
+			input = readline(get_colored_prompt());
+		else
+			input = readline(NO_INTERACTIVE_PROMPT_TEXT);
 		if (handle_eof(input))
 			break ;
 		process_input(input, &env, &last_exit);


### PR DESCRIPTION
## Descrição

Este PR implementa capacidade para verificar se o shell foi iniciado em modo interativo ou não.

> Resolve problema relatado na Issue https://github.com/peda-cos/minishell/issues/50

## Escopo das Modificações

- Adiciona validação se é modo não interativo.
- Processa fluxo sem leitura de `readline` quando for modo não interativo.
- Adiciona condicional para registrar `exit` somente quando for modo interativo.