### PR TITLE
Corrige comportamento com mais de um redirect de saída

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,9 +25,9 @@ BUILTIN_SRCS = sources/builtin/env.c sources/builtin/cd_utils.c \
 	sources/builtin/pwd.c sources/builtin/unset.c \
 	sources/builtin/exit.c sources/builtin/export.c sources/builtin/export_utils.c
 EXECUTOR_SRCS = sources/executor/main.c sources/executor/path_utils.c \
-	sources/executor/heredoc.c sources/executor/redirection.c \
+	sources/executor/redirection.c sources/executor/redirection_utils.c \
 	sources/executor/command_utils.c sources/executor/process.c \
-	sources/executor/process_utils.c
+	sources/executor/process_utils.c sources/executor/heredoc.c 
 TOKENIZER_SRCS = sources/tokenizer/utils.c sources/tokenizer/main.c \
 	sources/tokenizer/word.c sources/tokenizer/redirect.c \
 	sources/tokenizer/token.c

--- a/includes/structs.h
+++ b/includes/structs.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   structs.h                                          :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: peda-cos <peda-cos@student.42sp.org.br>    +#+  +:+       +#+        */
+/*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/20 22:48:48 by jlacerda          #+#    #+#             */
-/*   Updated: 2025/04/21 23:18:24 by peda-cos         ###   ########.fr       */
+/*   Updated: 2025/04/26 17:43:07 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -57,7 +57,8 @@ typedef struct s_command
 	struct s_command		*next;
 	char					**args;
 	char					*input_file;
-	char					*output_file;
+	char					**output_file_list;
+	int						amount_output_files;
 	char					*heredoc_delim;
 	int						heredoc_fd;
 }							t_command;

--- a/sources/executor/executor.h
+++ b/sources/executor/executor.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   executor.h                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: peda-cos <peda-cos@student.42sp.org.br>    +#+  +:+       +#+        */
+/*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/25 08:11:28 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/04/21 23:24:43 by peda-cos         ###   ########.fr       */
+/*   Updated: 2025/04/26 18:40:37 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -49,5 +49,11 @@ void	child_process(t_process_command_args *param);
 void	parent_process(t_process_command_args *param);
 int		process_command(t_command *cmd, char ***envs, int *last_exit,
 			t_token *tokens);
+
+int		setup_file_input(char *input_file);
+t_token	*get_fd_redirect_token(char *target_file, t_token *tokens);
+int		dup_fd_std(int fd, char *filename, t_process_command_args *arg);
+int		set_redirection_to_files(t_process_command_args *arg, int *flags);
+int		setup_input_redirection(t_command *cmd, char **env, int last_exit);
 
 #endif

--- a/sources/executor/process.c
+++ b/sources/executor/process.c
@@ -6,7 +6,7 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/25 08:19:21 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/04/21 14:15:47 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/04/26 17:48:41 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,17 +14,15 @@
 
 static int	setup_child_io(t_process_command_args *arg)
 {
-	int	setup_io_failure;
-
 	if (arg->cmd->next && arg->pipefd[1] > 0)
 	{
 		dup2(arg->pipefd[1], STDOUT_FILENO);
 		close(arg->pipefd[0]);
 		close(arg->pipefd[1]);
 	}
-	setup_io_failure = setup_output_redirection(arg) < 0
-		|| setup_input_redirection(arg->cmd, *arg->env, *arg->last_exit) < 0;
-	if (setup_io_failure)
+	if (setup_output_redirection(arg) < 0)
+		return (-1);
+	if (setup_input_redirection(arg->cmd, *arg->env, *arg->last_exit) < 0)
 		return (-1);
 	return (0);
 }
@@ -36,7 +34,7 @@ static int	handle_empty_command(t_command *cmd)
 
 	if (cmd->argc <= 0)
 	{
-		if (cmd->output_file != NULL)
+		if (cmd->output_file_list[0] != NULL)
 		{
 			bytes_read = read(STDIN_FILENO, buffer, sizeof(buffer));
 			while (bytes_read > 0)

--- a/sources/executor/redirection.c
+++ b/sources/executor/redirection.c
@@ -3,100 +3,25 @@
 /*                                                        :::      ::::::::   */
 /*   redirection.c                                      :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: peda-cos <peda-cos@student.42sp.org.br>    +#+  +:+       +#+        */
+/*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/25 08:15:40 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/04/21 23:25:27 by peda-cos         ###   ########.fr       */
+/*   Updated: 2025/04/26 18:40:37 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "executor.h"
 
-static int	setup_file_input(char *input_file)
-{
-	int	fd;
-
-	fd = open(input_file, O_RDONLY);
-	if (fd < 0)
-	{
-		perror(input_file);
-		return (-1);
-	}
-	dup2(fd, STDIN_FILENO);
-	close(fd);
-	return (0);
-}
-
-int	setup_input_redirection(t_command *cmd, char **env, int last_exit)
-{
-	if (!cmd)
-		return (-1);
-	if (cmd->heredoc_fd >= 0)
-	{
-		if (dup2(cmd->heredoc_fd, STDIN_FILENO) < 0)
-		{
-			perror("dup2");
-			close(cmd->heredoc_fd);
-			return (-1);
-		}
-		close(cmd->heredoc_fd);
-		cmd->heredoc_fd = -1;
-		return (0);
-	}
-	else if (cmd->heredoc_delim)
-	{
-		return (handle_heredoc(cmd->heredoc_delim, env, last_exit));
-	}
-	else if (cmd->input_file)
-	{
-		return (setup_file_input(cmd->input_file));
-	}
-	return (0);
-}
-
-static int	has_fd_redirect_to_stderr(t_process_command_args *arg)
-{
-	t_token	*tmp;
-	int		redirect_fd;
-
-	tmp = arg->tokens;
-	redirect_fd = FALSE;
-	while (tmp && ft_strcmp(tmp->content->value, arg->cmd->output_file) != 0)
-	{
-		if (tmp->type == FILE_DESCRIPTOR
-			&& ft_atoi(tmp->content->value) == STDERR_FILENO)
-		{
-			arg->has_fd_redirect_to_stderr = TRUE;
-			redirect_fd = TRUE;
-			break ;
-		}
-		tmp = tmp->next;
-	}
-	return (redirect_fd);
-}
-
 int	setup_output_redirection(t_process_command_args *param)
 {
-	int	fd;
 	int	flags;
 
-	if (!param->cmd->output_file)
-		return (0);
 	flags = O_WRONLY | O_CREAT;
 	if (param->cmd->append)
 		flags |= O_APPEND;
 	else
 		flags |= O_TRUNC;
-	fd = open(param->cmd->output_file, flags, 0644);
-	if (fd < 0)
-	{
-		perror(param->cmd->output_file);
+	if (set_redirection_to_files(param, &flags) < 0)
 		return (-1);
-	}
-	if (has_fd_redirect_to_stderr(param))
-		dup2(fd, STDERR_FILENO);
-	else
-		dup2(fd, STDOUT_FILENO);
-	close(fd);
 	return (0);
 }

--- a/sources/executor/redirection_utils.c
+++ b/sources/executor/redirection_utils.c
@@ -1,0 +1,108 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   redirection_utils.c                                :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/04/26 08:15:40 by jlacerda          #+#    #+#             */
+/*   Updated: 2025/04/26 18:40:37 by jlacerda         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "executor.h"
+
+int	setup_file_input(char *input_file)
+{
+	int	fd;
+
+	fd = open(input_file, O_RDONLY);
+	if (fd < 0)
+	{
+		perror(input_file);
+		return (-1);
+	}
+	dup2(fd, STDIN_FILENO);
+	close(fd);
+	return (0);
+}
+
+int	setup_input_redirection(t_command *cmd, char **env, int last_exit)
+{
+	if (!cmd)
+		return (-1);
+	if (cmd->heredoc_fd >= 0)
+	{
+		if (dup2(cmd->heredoc_fd, STDIN_FILENO) < 0)
+		{
+			perror("dup2");
+			close(cmd->heredoc_fd);
+			return (-1);
+		}
+		close(cmd->heredoc_fd);
+		cmd->heredoc_fd = -1;
+		return (0);
+	}
+	else if (cmd->heredoc_delim)
+	{
+		return (handle_heredoc(cmd->heredoc_delim, env, last_exit));
+	}
+	else if (cmd->input_file)
+	{
+		return (setup_file_input(cmd->input_file));
+	}
+	return (0);
+}
+
+t_token	*get_fd_redirect_token(char *target_file, t_token *tokens)
+{
+	t_token	*tmp;
+
+	tmp = tokens;
+	while (tmp)
+	{
+		if (tmp->type == FILE_DESCRIPTOR
+			&& ft_strcmp(tmp->next->next->content->value, target_file) == 0)
+			return (tmp);
+		tmp = tmp->next;
+	}
+	return (NULL);
+}
+
+int	dup_fd_std(int fd, char *filename, t_process_command_args *arg)
+{
+	t_token	*fd_redirect_token;
+
+	fd_redirect_token = get_fd_redirect_token(filename, arg->tokens);
+	if (fd_redirect_token
+		&& ft_atoi(fd_redirect_token->content->value) == STDERR_FILENO)
+		return (dup2(fd, STDERR_FILENO));
+	return (dup2(fd, STDOUT_FILENO));
+}
+
+int	set_redirection_to_files(t_process_command_args *arg, int *flags)
+{
+	int		fd;
+	int		index;
+	char	**output_file_list;
+
+	index = 0;
+	output_file_list = arg->cmd->output_file_list;
+	while (index < arg->cmd->amount_output_files)
+	{
+		fd = open(output_file_list[index], *flags, 0644);
+		if (fd < 0)
+		{
+			perror(output_file_list[index]);
+			return (-1);
+		}
+		if (dup_fd_std(fd, output_file_list[index], arg) < 0)
+		{
+			close(fd);
+			return (-1);
+		}
+		close(fd);
+		index++;
+	}
+	return (0);
+}

--- a/sources/free.c
+++ b/sources/free.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   free.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: peda-cos <peda-cos@student.42sp.org.br>    +#+  +:+       +#+        */
+/*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/26 14:54:34 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/04/21 23:19:54 by peda-cos         ###   ########.fr       */
+/*   Updated: 2025/04/26 17:45:48 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -64,14 +64,14 @@ void	free_commands(t_command *cmd)
 		if (cmd->args)
 		{
 			while (cmd->args[i])
-			{
-				free(cmd->args[i]);
-				i++;
-			}
+				free(cmd->args[i++]);
 			free(cmd->args);
 		}
 		free(cmd->input_file);
-		free(cmd->output_file);
+		i = 0;
+		while (i < cmd->amount_output_files)
+			free(cmd->output_file_list[i++]);
+		free(cmd->output_file_list);
 		free(cmd->heredoc_delim);
 		if (cmd->heredoc_fd >= 0)
 			close(cmd->heredoc_fd);

--- a/sources/parser/main.c
+++ b/sources/parser/main.c
@@ -3,47 +3,56 @@
 /*                                                        :::      ::::::::   */
 /*   main.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: peda-cos <peda-cos@student.42sp.org.br>    +#+  +:+       +#+        */
+/*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/26 14:40:39 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/04/21 22:21:36 by peda-cos         ###   ########.fr       */
+/*   Updated: 2025/04/26 18:47:12 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "parser.h"
 
-static void	set_redirection_target(t_command *cmd, t_token *token,
-		t_content_params *content_params)
+static void	set_output_redirect_file(char *value,
+	t_command	*cmd, int is_append)
 {
-	char	*value;
+	int	index;
 
-	value = get_token_content_value(content_params);
-	if (!value)
+	index = cmd->amount_output_files;
+	if (index < OUTPUT_FILES_MAX_SIZE)
+	{
+		if (cmd->output_file_list[index])
+			free(cmd->output_file_list[index]);
+		cmd->output_file_list[index] = value;
+		cmd->output_file_list[index + 1] = NULL;
+		cmd->amount_output_files++;
+		cmd->append = is_append;
+	}
+}
+
+static void	set_redirection_target(t_command *cmd,
+	t_token *token, t_content_params *content_params)
+{
+	char	*filename;
+
+	filename = get_token_content_value(content_params);
+	if (!filename)
 		return ;
 	if (token->type == REDIRECT_IN)
 	{
 		free(cmd->input_file);
-		cmd->input_file = value;
+		cmd->input_file = filename;
 	}
 	else if (token->type == REDIRECT_OUT)
-	{
-		free(cmd->output_file);
-		cmd->output_file = value;
-		cmd->append = 0;
-	}
+		set_output_redirect_file(filename, cmd, FALSE);
 	else if (token->type == APPEND)
-	{
-		free(cmd->output_file);
-		cmd->output_file = value;
-		cmd->append = 1;
-	}
+		set_output_redirect_file(filename, cmd, TRUE);
 	else if (token->type == HEREDOC)
 	{
 		free(cmd->heredoc_delim);
-		cmd->heredoc_delim = value;
+		cmd->heredoc_delim = filename;
 	}
 	else
-		free(value);
+		free(filename);
 }
 
 static int	create_output_file(char *filename, int append)

--- a/sources/parser/parser.h
+++ b/sources/parser/parser.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   parser.h                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: peda-cos <peda-cos@student.42sp.org.br>    +#+  +:+       +#+        */
+/*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/25 01:33:23 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/04/21 22:21:37 by peda-cos         ###   ########.fr       */
+/*   Updated: 2025/04/26 18:59:50 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,8 +15,8 @@
 
 # include "minishell.h"
 
+# define OUTPUT_FILES_MAX_SIZE 25
 # define SYNTAX_ERROR_MSG "minishell: syntax error near unexpected token\n"
-
 /*
 ** Parser context structure to reduce parameter count in functions
 */

--- a/sources/parser/utils.c
+++ b/sources/parser/utils.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   utils.c                                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: peda-cos <peda-cos@student.42sp.org.br>    +#+  +:+       +#+        */
+/*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/25 01:31:04 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/04/21 22:21:40 by peda-cos         ###   ########.fr       */
+/*   Updated: 2025/04/26 17:42:48 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -28,7 +28,9 @@ static t_command	*new_command(void)
 	cmd->args = NULL;
 	cmd->argc = 0;
 	cmd->input_file = NULL;
-	cmd->output_file = NULL;
+	cmd->output_file_list = malloc(sizeof(char *) * OUTPUT_FILES_MAX_SIZE);
+	cmd->output_file_list[0] = NULL;
+	cmd->amount_output_files = 0;
 	cmd->append = 0;
 	cmd->heredoc_delim = NULL;
 	cmd->next = NULL;


### PR DESCRIPTION
## Descrição

Este PR implementa capacidade de processamento do comando quando existir mais de um redirecionamento de saída, deixando-o semelhante ao comportamento do `bash`

Exemplo: `fail 2> f_err 1> f_out 2> f_err2 | echo OK > e_out 1> e_out2 2> e_err`

Na execução do lado esquerdo do pipe, deve registrar saída de error apenas no `f_err2` e na saída padrão não registrar nada.

Na execução do lado direito, deve regsitrar a saída padrão apenas no `e_out2` e na saída de error não registrar nada.

## Escopo das Modificações

- Adiciona captura de mais de um arquivo a ser processado para redirecionamento de saída.
- Atualiza função `setup_output_redirection` para processar o redirecionamento para os arquivos de saída quando identificado FD junto do redirect.
- Modifica liberação de memória dos arquivos armazenados na lista.

## Resultado

> Bash

```bash
jlacerda@c1r7p1:~/ft/minishell$ echo $0
bash
jlacerda@c1r7p1:~/ft/minishell$ fail 2> f_err 1> f_out 2> f_err2 | echo OK > e_out 1> e_out2 2> e_err
jlacerda@c1r7p1:~/ft/minishell$ cat f_err
jlacerda@c1r7p1:~/ft/minishell$ cat f_out
jlacerda@c1r7p1:~/ft/minishell$ cat f_err2
Command 'fail' not found, did you mean: ...
jlacerda@c1r7p1:~/ft/minishell$ cat e_err
jlacerda@c1r7p1:~/ft/minishell$ cat e_out
jlacerda@c1r7p1:~/ft/minishell$ cat e_out2
OK
```

> Minishell

```bash
🧙 Minishell ❯ fail 2> f_err 1> f_out 2> f_err2 | echo OK > e_out 1> e_out2 2> e_err
🧙 Minishell ❯ cat f_err
🧙 Minishell ❯ cat f_out
🧙 Minishell ❯ cat f_err2
minishell: fail: command not found
🧙 Minishell ❯ cat e_err
🧙 Minishell ❯ cat e_out
🧙 Minishell ❯ cat e_out2
OK
```