### PR TITLE
Corrige abordagem de processamento de comando quando ocorrer expansão

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,9 +17,10 @@ LIBFT_DIR = ./libft
 OBJS_DIR = ./objects
 INCS_DIR = ./includes
 
-MAIN_SRCS = sources/main.c sources/utils.c \
-	sources/cmd_utils.c sources/free.c sources/gay.c
-PARSER_SRCS = sources/parser/main.c sources/parser/utils.c
+MAIN_SRCS = sources/main.c \
+	sources/utils.c sources/free.c sources/gay.c
+PARSER_SRCS = sources/parser/main.c \
+	sources/parser/utils.c sources/parser/cmd_utils.c
 HANDLER_SRCS = sources/handler/main.c sources/handler/utils.c
 BUILTIN_SRCS = sources/builtin/env.c sources/builtin/cd_utils.c \
 	sources/builtin/cd.c sources/builtin/echo.c \

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/19 19:15:26 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/04/25 00:19:05 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/04/28 21:21:46 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -32,7 +32,7 @@
 # include <readline/readline.h>
 
 /* Main Utils */
-void		update_cmd_args_with_spaces(t_command *cmd);
+void		update_cmd_args_when_expanded(t_command *cmd);
 int			process_tokens(t_token **tokens, int *last_exit);
 void		process_input(char *input, char ***env, int *last_exit);
 void		execute_parent_builtin(
@@ -61,8 +61,7 @@ void		free_commands(t_command *cmd);
 void		free_token_content(t_token_content *content);
 
 /* Utility for variable expansion */
-char		*expand_variable(char *str, char **envs, int last_exit,
-				int *has_error_flag_control);
+char		*expand_variable(char *str, t_expansion_ctx *exp);
 
 /* Tokenizer: splits input into tokens */
 t_token		*tokenize_input(char *input);

--- a/includes/structs.h
+++ b/includes/structs.h
@@ -6,7 +6,7 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/20 22:48:48 by jlacerda          #+#    #+#             */
-/*   Updated: 2025/04/26 22:58:34 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/04/28 21:01:27 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -30,6 +30,7 @@ typedef struct s_token_content
 	struct s_token_content	*next;
 	char					*value;
 	int						in_quotes;
+	int						was_expanded;
 	int						in_single_quotes;
 }							t_token_content;
 
@@ -74,5 +75,13 @@ typedef struct s_process_command_args
 	t_token					*tokens;
 	int						has_fd_redirect_to_stderr;
 }							t_process_command_args;
+
+typedef struct s_expansion_ctx
+{
+	char			**envs;
+	t_token_content	*content;
+	int				*last_exit;
+	int				*has_error_flag_control;
+}	t_expansion_ctx;
 
 #endif

--- a/sources/builtin/builtin.h
+++ b/sources/builtin/builtin.h
@@ -6,7 +6,7 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/25 14:15:36 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/04/21 14:46:12 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/04/28 21:07:42 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -32,7 +32,7 @@ int		builtin_exit(t_process_command_args	*param);
 /* Utility functions */
 int		is_valid_key(char *key);
 void	print_invalid_arg(char *arg);
-char	*get_env_value(char *key, char **env);
+char	*get_env_value(char *key, char **envs, t_token_content *content);
 
 /* CD Utility functions */
 void	update_pwd_env(char *old_pwd, char ***env);

--- a/sources/builtin/cd_utils.c
+++ b/sources/builtin/cd_utils.c
@@ -6,7 +6,7 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/31 21:16:04 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/04/19 16:52:25 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/04/28 21:07:43 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -56,7 +56,7 @@ int	change_to_previous(char ***env, char *old_pwd)
 {
 	char	*prev_pwd;
 
-	prev_pwd = get_env_value("OLDPWD", *env);
+	prev_pwd = get_env_value("OLDPWD", *env, NULL);
 	if (!prev_pwd)
 	{
 		ft_putstr_fd("cd: OLDPWD not set\n", STDERR_FILENO);
@@ -78,7 +78,7 @@ int	change_to_home(char ***env, char *old_pwd)
 {
 	char	*home;
 
-	home = get_env_value("HOME", *env);
+	home = get_env_value("HOME", *env, NULL);
 	if (!home)
 	{
 		ft_putstr_fd("cd: HOME not set\n", STDERR_FILENO);

--- a/sources/executor/heredoc.c
+++ b/sources/executor/heredoc.c
@@ -6,7 +6,7 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/25 08:12:39 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/04/24 22:59:37 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/04/28 21:35:06 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -39,13 +39,17 @@ static int	is_quoted_delimiter(char *delim)
 static char	*process_heredoc_line(char *line, char **env, int last_exit,
 		int expand_vars)
 {
-	char	*expanded;
-	int		has_error;
+	char			*expanded;
+	int				has_error;
+	t_expansion_ctx	expansion_cxt;
 
 	has_error = FALSE;
 	if (!expand_vars)
 		return (ft_strdup(line));
-	expanded = expand_variable(line, env, last_exit, &has_error);
+	expansion_cxt.envs = env;
+	expansion_cxt.last_exit = &last_exit;
+	expansion_cxt.has_error_flag_control = &has_error;
+	expanded = expand_variable(line, &expansion_cxt);
 	return (expanded);
 }
 

--- a/sources/expansion/expansion.h
+++ b/sources/expansion/expansion.h
@@ -6,7 +6,7 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/31 14:20:01 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/04/24 23:34:29 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/04/28 21:07:16 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,13 +15,7 @@
 
 # include "minishell.h"
 
-typedef struct s_expansion_ctx
-{
-	char	**env;
-	int		last_exit;
-}			t_expansion_ctx;
-
-char	*get_env_value(char *key, char **env);
+char	*get_env_value(char *key, char **envs, t_token_content *content);
 char	*get_underscore_arg_value(char **envs);
 void	set_underscore_arg_value(t_command *cmd, char ***envs);
 char	*extract_var_name_in_brackets_entered(char *str, int *index);

--- a/sources/expansion/main.c
+++ b/sources/expansion/main.c
@@ -6,7 +6,7 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/31 21:50:10 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/04/27 15:08:41 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/04/28 21:55:56 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,13 +23,13 @@ static char	*extract_var_name(const char *str, int *index)
 }
 
 static char	*extract_env_value(
-	char *str, char **envs, int last_exit, int *index)
+	char *str, int *index, t_expansion_ctx *exp)
 {
 	char	*var;
 	char	*value;
 	int		in_brackets_entered;
 
-	value = get_special_variable(str, index, envs, last_exit);
+	value = get_special_variable(str, index, exp->envs, *exp->last_exit);
 	if (value)
 	{
 		(*index)++;
@@ -44,7 +44,7 @@ static char	*extract_env_value(
 		return (NULL);
 	if (!var)
 		return (ft_strdup(""));
-	value = get_env_value(var, envs);
+	value = get_env_value(var, exp->envs, exp->content);
 	free(var);
 	if (!value)
 		return (ft_strdup(""));
@@ -74,8 +74,7 @@ static void	process_expansion(char **result, char **value,
 	*result = extract_result(*value, *result);
 }
 
-char	*expand_variable(char *str,
-	char **envs, int last_exit, int *has_error_flag_control)
+char	*expand_variable(char *str, t_expansion_ctx *exp)
 {
 	int		i;
 	int		start;
@@ -97,8 +96,8 @@ char	*expand_variable(char *str,
 		if (str[i] == '$')
 		{
 			i++;
-			value = extract_env_value(str, envs, last_exit, &i);
-			process_expansion(&result, &value, has_error_flag_control);
+			value = extract_env_value(str, &i, exp);
+			process_expansion(&result, &value, exp->has_error_flag_control);
 		}
 	}
 	return (result);

--- a/sources/expansion/utils.c
+++ b/sources/expansion/utils.c
@@ -6,27 +6,29 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/31 21:00:10 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/04/26 23:50:47 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/04/28 21:07:40 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "expansion.h"
 
-char	*get_env_value(char *key, char **env)
+char	*get_env_value(char *key, char **envs, t_token_content *content)
 {
 	int		i;
 	int		key_len;
 	char	*value;
 
-	if (!key || !env)
+	if (!key || !envs)
 		return (NULL);
 	key_len = ft_strlen(key);
 	i = 0;
-	while (env[i])
+	while (envs[i])
 	{
-		if (ft_strncmp(env[i], key, key_len) == 0 && env[i][key_len] == '=')
+		if (ft_strncmp(envs[i], key, key_len) == 0 && envs[i][key_len] == '=')
 		{
-			value = ft_strdup(env[i] + key_len + 1);
+			value = ft_strdup(envs[i] + key_len + 1);
+			if (content)
+				content->was_expanded = TRUE;
 			return (value);
 		}
 		i++;
@@ -38,7 +40,7 @@ char	*get_underscore_arg_value(char **envs)
 {
 	char	*value;
 
-	value = get_env_value("_", envs);
+	value = get_env_value("_", envs, NULL);
 	if (!value)
 		return (getcwd(NULL, 0));
 	return (value);

--- a/sources/parser/cmd_utils.c
+++ b/sources/parser/cmd_utils.c
@@ -6,7 +6,7 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/27 19:37:02 by jlacerda          #+#    #+#             */
-/*   Updated: 2025/04/27 20:36:21 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/04/28 21:21:46 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -79,7 +79,7 @@ static int	process_command_arg(char **new_args, int *new_idx, char *arg)
 	return (TRUE);
 }
 
-void	update_cmd_args_with_spaces(t_command *cmd)
+void	update_cmd_args_when_expanded(t_command *cmd)
 {
 	int		i;
 	char	**new_args;

--- a/sources/parser/main.c
+++ b/sources/parser/main.c
@@ -6,7 +6,7 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/26 14:40:39 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/04/28 17:52:00 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/04/28 21:21:46 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -162,6 +162,8 @@ static t_token	*process_token(t_token *token, t_parser_context *parser,
 		content_params.last_exit_code = last_exit;
 		content_params.content = token->content;
 		arg_val = get_token_content_value(&content_params);
+		if (token->content->was_expanded)
+			update_cmd_args_when_expanded(parser->current);
 		if (!arg_val)
 		{
 			cleanup_parser_on_error(parser);

--- a/sources/utils.c
+++ b/sources/utils.c
@@ -6,7 +6,7 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/19 19:05:27 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/04/28 18:05:15 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/04/28 21:19:31 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -124,7 +124,6 @@ void	process_input(char *input, char ***env, int *last_exit)
 	if (process_tokens(&tokens, last_exit))
 		return ;
 	cmd = parse_tokens(tokens, *env, *last_exit);
-	update_cmd_args_with_spaces(cmd);
 	if (cmd == NULL || cmd->args == NULL || *cmd->args[0] == '\0')
 		return (process_invalid_command(cmd, last_exit, tokens));
 	preprocess_heredocs(cmd);


### PR DESCRIPTION
# Parser

> Corrige abordagem de processamento de comando quando ocorrer expansão

Este Pull Request refatora e melhora o código do projeto **Minishell**, com foco em modularidade, clareza e suporte a novas funcionalidades. As mudanças incluem a introdução de uma nova estrutura para o contexto de expansão de variáveis, ajustes em funções existentes, reorganização de arquivos e melhorias na lógica de expansão de variáveis e processamento de comandos.

## 🔄 Alterações Principais

- **Makefile**:
  - Reorganização das fontes:
    - Arquivo `cmd_utils.c` movido para `sources/parser/` e renomeado.
    - Ajuste nas variáveis `MAIN_SRCS` e `PARSER_SRCS` para refletir a nova organização.

- **Estruturas e Contextos**:
  - Adicionada a estrutura `t_expansion_ctx` em `includes/structs.h`:
    - Centraliza o contexto de expansão de variáveis, incluindo:
      - Ambiente (`envs`).
      - Último código de saída (`last_exit`).
      - Controle de erros (`has_error_flag_control`).
      - Conteúdo do token (`content`).

- **Expansão de Variáveis**:
  - Refatoração da função `expand_variable`:
    - Agora utiliza a nova estrutura `t_expansion_ctx`.
    - Simplifica a passagem de parâmetros e melhora a legibilidade.
  - Atualização de `get_env_value` para aceitar o parâmetro `t_token_content`:
    - Marca tokens como "expandidos" quando aplicável.

- **Parser**:
  - Adicionada a chamada de `update_cmd_args_when_expanded`:
    - Atualiza os argumentos do comando quando tokens são expandidos.

- **Heredoc**:
  - Refatoração no processamento de linhas do heredoc:
    - Uso do novo contexto `t_expansion_ctx` para processar variáveis.

## 🛠️ Arquivos Modificados

- **Makefile**: Ajustes nas variáveis de fontes.
- **includes/minishell.h**: Atualização de assinaturas de funções.
- **includes/structs.h**: Adição da estrutura `t_expansion_ctx`.
- **sources/parser/main.c**: Adição de lógica para atualização de argumentos expandidos.
- **sources/expansion/main.c**: Refatoração da lógica de expansão de variáveis.
- **sources/executor/heredoc.c**: Uso do novo contexto de expansão.
- **sources/builtin/cd_utils.c**: Ajuste em chamadas de `get_env_value`.
- **sources/tokenizer/token.c**: Adição de suporte para rastreamento de tokens expandidos.
