### PR TITLE
fix(expansion): fixes logic for tilde expansion `~`

### DIFF
--- a/sources/parser/redirect.c
+++ b/sources/parser/redirect.c
@@ -6,7 +6,7 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/27 19:37:02 by jlacerda          #+#    #+#             */
-/*   Updated: 2025/05/04 21:04:11 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/05/05 23:58:12 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -116,7 +116,7 @@ void	set_redirection_target(t_command *cmd,
 		set_output_redirect_file(filename, cmd, TRUE);
 	else if (token->type == HEREDOC)
 		process_heredoc_delim(content_params->content, cmd);
-	else 
+	else
 		free(filename);
 }
 

--- a/sources/tokenizer/token.c
+++ b/sources/tokenizer/token.c
@@ -6,7 +6,7 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/22 13:18:28 by jlacerda          #+#    #+#             */
-/*   Updated: 2025/05/04 19:08:27 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/05/05 22:36:28 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -97,28 +97,6 @@ static char	*append_to_final_value(char *final_value,
 }
 
 /**
- * @brief Processes the final value of the token content
- * @param final_value The final value string to append to
- * @param params The parameters for processing the content
- * @param content The token content to process
- * @return Pointer to the updated final value string, or NULL on error
- * @note Allocates memory for the new string and frees the old one
- */
-static char	*process_final_value(char *final_value,
-	t_content_params *params, t_token_content *content)
-{
-	char	*temp;
-
-	if (content->value[0] == '~' && content->value[1] == '\0')
-	{
-		temp = content->value;
-		content->value = get_env_value("HOME", params->envs);
-		free(temp);
-	}
-	return (append_to_final_value(final_value, content, params));
-}
-
-/**
  * @brief Processes the content of the token and returns the final value
  * @param params The parameters for processing the content
  * @return Pointer to the final value string, or NULL on error
@@ -144,7 +122,7 @@ char	*get_token_content_value(t_content_params *params)
 			content = content->next;
 			continue ;
 		}
-		final_value = process_final_value(final_value, params, content);
+		final_value = append_to_final_value(final_value, content, params);
 		if (!final_value)
 			return (NULL);
 		content = content->next;


### PR DESCRIPTION
## 📝 Descrição

Altera abordagem de expansão do til `~`, removendo a lógica da tokenização e centralização na expansão, responsável por expandir, pois a navegação `cd` ou exibição de conteúdo do diretório `ls` estavam divergentes entre o bash e o minishel.

Essa mudança garante expansão do til além de cenários isolados `cd ~`, permitindo a navegação usando til com pastas `cd ~/some_folder/inner_folder` ou `ls ~/some_folder`.

### Bash

```bash
jlacerda@c1r6p1:~/ft/minishell$ ls ~/ft/minishell/
42_minishell_tester  bash  echo      leaks.supp  Makefile  minishell         objects  README.md  tmp_err_bash       tmp_out_bash       tmp_test
annotations          diff  includes  libft       mini      minishell_tester  out      sources    tmp_err_minishell  tmp_out_minishell  tmp_valgrind-out.txt
jlacerda@c1r6p1:~/ft/minishell$ ls ~/ft/minishell/includes/
macros.h  minishell.h  structs.h
jlacerda@c1r6p1:~/ft/minishell$ cd ~/ft/minishell/includes/
jlacerda@c1r6p1:~/ft/minishell/includes$ pwd
/nfs/homes/jlacerda/ft/minishell/includes
jlacerda@c1r6p1:~/ft/minishell/includes$ export HOME_VALUE=~
jlacerda@c1r6p1:~/ft/minishell/includes$ echo $HOME_VALUE
/nfs/homes/jlacerda
```

### Minishell (`após modificação`)

```bash
🧙 jlacerda 🔥 ~/ft/minishell ❯ ls ~/ft/minishell/
42_minishell_tester  bash  echo      leaks.supp  Makefile  minishell         objects    sources       tmp_err_minishell  tmp_out_minishell  tmp_valgrind-out.txt
annotations          diff  includes  libft       mini      minishell_tester  README.md  tmp_err_bash  tmp_out_bash       tmp_test
🧙 jlacerda 🔥 ~/ft/minishell ❯ ls ~/ft/minishell/includes/
macros.h  minishell.h  structs.h
🧙 jlacerda 🔥 ~/ft/minishell ❯ cd ~/ft/minishell/includes/
🧙 jlacerda 🔥 ~/ft/minishell/includes ❯ pwd
/nfs/homes/jlacerda/ft/minishell/includes
🧙 jlacerda 🔥 ~/ft/minishell/includes ❯ export HOME_VAL=~
🧙 jlacerda 🔥 ~/ft/minishell/includes ❯ echo $HOME_VAL
/nfs/homes/jlacerda
```
