### PR TITLE
Correção de vazamentos de memória em operações com pipe

### DIFF
--- a/includes/macros.h
+++ b/includes/macros.h
@@ -6,7 +6,7 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/19 19:15:26 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/05/03 15:38:42 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/05/08 23:09:40 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,7 +15,6 @@
 # define TRUE 1
 # define FALSE 0
 
-/* Tokenizer ------------ */
 # define NULL_CHR '\0'
 # define PIPE_CHR '|'
 # define BACKSLASH_CHR '\\'
@@ -41,7 +40,7 @@
 # define REDIRECT_OUT_STR ">"
 # define SINGLE_QUOTE_STR "'"
 # define DOUBLE_QUOTE_STR "\""
-/* ----------------------- */
+# define FD_LIST_SIZE 42
 
 /* Prompt ---------------- */
 # define MAX_PROMPT_LENGTH 1024

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/19 19:15:26 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/05/03 16:41:39 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/05/08 23:28:46 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -62,7 +62,7 @@ int			setup_output_redirection(t_process_command_args *param);
 /* Memory cleanup */
 void		free_tokens(t_token *tokens);
 void		free_commands(t_command *cmd);
-void		free_token_content(t_token_content *content);
+void		manager_file_descriptors(t_manager_fd fd_type, int fd);
 
 /* Utility for variable expansion */
 char		*expand_variable(char *str, t_expansion_ctx *exp);

--- a/includes/structs.h
+++ b/includes/structs.h
@@ -6,7 +6,7 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/20 22:48:48 by jlacerda          #+#    #+#             */
-/*   Updated: 2025/05/08 23:52:32 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/05/09 20:37:10 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -143,6 +143,7 @@ typedef struct s_process_command_args
 	int						pid;
 	char					***env;
 	t_command				*cmd;
+	t_command				*head;
 	int						pipefd[2];
 	int						*last_exit;
 	t_token					*tokens;

--- a/includes/structs.h
+++ b/includes/structs.h
@@ -6,12 +6,22 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/20 22:48:48 by jlacerda          #+#    #+#             */
-/*   Updated: 2025/05/04 19:47:07 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/05/08 23:52:32 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #ifndef STRUCTS_H
 # define STRUCTS_H
+
+/**
+ * @brief Enumeration of file descriptor management options
+ * @enum t_manager_fd
+ */
+typedef enum e_manager_fd
+{
+	ADD,
+	FREE,
+}	t_manager_fd;
 
 /**
  * @brief Enumeration of token types supported by the minishell parser

--- a/leaks.supp
+++ b/leaks.supp
@@ -10,3 +10,15 @@
    ...
    obj:*/libtinfo.so*
 }
+{
+   <VSCode FD Engine>
+   Memcheck:Leak
+   ...
+   obj:*/code/v8*
+}
+{
+   <VSCode FD Events>
+   Memcheck:Leak
+   ...
+   obj:*/Code/logs/*
+}

--- a/sources/executor/executor.h
+++ b/sources/executor/executor.h
@@ -6,7 +6,7 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/25 08:11:28 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/05/02 20:10:02 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/05/09 20:43:26 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -53,8 +53,7 @@ int		setup_pipe(t_command *cmd, int pipefd[2]);
 int		setup_child_io(t_process_command_args *arg);
 void	child_process(t_process_command_args *param);
 void	parent_process(t_process_command_args *param);
-int		process_command(t_command *cmd, char ***envs, int *last_exit,
-			t_token *tokens);
+int		process_command(t_command *cmd, t_process_command_args *args);
 
 int		setup_file_input(char *input_file);
 t_token	*get_fd_redirect_token(char *target_file, t_token *tokens);

--- a/sources/executor/main.c
+++ b/sources/executor/main.c
@@ -6,7 +6,7 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/26 15:01:28 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/05/04 19:41:02 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/05/09 01:06:17 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -32,6 +32,7 @@ static int	setup_command_execution(t_command *cmd, char **env, int *last_exit)
 		perror("dup");
 		return (-1);
 	}
+	manager_file_descriptors(ADD, backup_fd);
 	return (backup_fd);
 }
 

--- a/sources/executor/main.c
+++ b/sources/executor/main.c
@@ -6,7 +6,7 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/26 15:01:28 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/05/09 21:21:45 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/05/09 21:45:17 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -50,14 +50,14 @@ static int	has_pipeline(t_command *cmd)
 }
 
 /**
- * @brief Processes a single command in the command chain
- * @param cmd The command structure to be executed
- * @param env Array of environment variables
- * @param last_exit Pointer to the last exit status
- * @param tokens Pointer to the token list for cleanup during exit
- * @return 0 on success, -1 on error
- * @note Handles the execution of a single command and its arguments
- */
+	* @brief Processes a chain of commands
+	* @param cmd_head The head of the command list
+	* @param env Array of environment variables
+	* @param last_exit Pointer to the last exit status
+	* @param tokens Pointer to the token list for cleanup during exit
+	* @return 0 on success, -1 on error
+	* @note Iterates through the command list and processes each command
+	*/
 static int	process_command_chain(t_command *cmd_head,
 	char ***env, int *last_exit, t_token *tokens)
 {

--- a/sources/executor/main.c
+++ b/sources/executor/main.c
@@ -6,7 +6,7 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/26 15:01:28 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/05/09 01:06:17 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/05/09 21:21:45 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -58,14 +58,21 @@ static int	has_pipeline(t_command *cmd)
  * @return 0 on success, -1 on error
  * @note Handles the execution of a single command and its arguments
  */
-static int	process_command_chain(t_command *cmd, char ***env, int *last_exit,
-		t_token *tokens)
+static int	process_command_chain(t_command *cmd_head,
+	char ***env, int *last_exit, t_token *tokens)
 {
-	int	result;
+	t_command				*cmd;
+	t_process_command_args	args;
+	int						result;
 
+	cmd = cmd_head;
+	args.env = env;
+	args.head = cmd_head;
+	args.tokens = tokens;
+	args.last_exit = last_exit;
 	while (cmd)
 	{
-		result = process_command(cmd, env, last_exit, tokens);
+		result = process_command(cmd, &args);
 		if (result < 0)
 			return (-1);
 		cmd = cmd->next;

--- a/sources/executor/process.c
+++ b/sources/executor/process.c
@@ -6,7 +6,7 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/25 08:19:21 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/05/09 21:32:28 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/05/09 21:46:27 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -119,11 +119,9 @@ void	parent_process(t_process_command_args *param)
 }
 
 /**
- * @brief Processes the command and its arguments
+ * @brief Sets up the command for execution
  * @param cmd The command structure to be executed
- * @param envs Array of environment variables
- * @param last_exit Pointer to the last exit status
- * @param tokens Pointer to the token list for cleanup during exit
+ * @param args The command arguments and environment variables
  * @return 0 on success, -1 on error
  * @note Sets up pipes and forks a child process for command execution
  */

--- a/sources/executor/process.c
+++ b/sources/executor/process.c
@@ -6,7 +6,7 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/25 08:19:21 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/05/04 18:54:54 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/05/09 21:32:28 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -75,14 +75,15 @@ void	child_process(t_process_command_args *param)
 	sigaction(SIGINT, &sa, NULL);
 	sigaction(SIGQUIT, &sa, NULL);
 	if (setup_child_io(param) < 0)
-		exit_free(1, param->env, param->cmd, param->tokens);
+		exit_free(1, param->env, param->head, param->tokens);
 	if (handle_empty_command(param->cmd))
-		exit_free(0, param->env, param->cmd, param->tokens);
+		exit_free(0, param->env, param->head, param->tokens);
 	if (is_builtin(param->cmd->args[0]))
-		exit_free(execute_builtin(param), param->env, param->cmd,
-			param->tokens);
-	exit_free(execute_external(param->cmd, *param->env), param->env, param->cmd,
-		param->tokens);
+		exit_free(execute_builtin(param),
+			param->env, param->head, param->tokens);
+	else
+		exit_free(execute_external(param->cmd, *param->env),
+			param->env, param->head, param->tokens);
 }
 
 /**
@@ -126,32 +127,27 @@ void	parent_process(t_process_command_args *param)
  * @return 0 on success, -1 on error
  * @note Sets up pipes and forks a child process for command execution
  */
-int	process_command(t_command *cmd, char ***envs, int *last_exit,
-		t_token *tokens)
+int	process_command(t_command *cmd, t_process_command_args *args)
 {
 	int						pipefd[2];
-	t_process_command_args	args;
 
-	if (!cmd || !envs || !last_exit)
+	if (!cmd || !args->env || !args->last_exit)
 		return (-1);
 	if (setup_pipe(cmd, pipefd) < 0)
 		return (-1);
-	args.cmd = cmd;
-	args.env = envs;
-	args.tokens = tokens;
-	args.last_exit = last_exit;
-	args.pid = fork();
-	args.pipefd[0] = pipefd[0];
-	args.pipefd[1] = pipefd[1];
-	args.has_fd_redirect_to_stderr = FALSE;
-	if (args.pid < 0)
+	args->cmd = cmd;
+	args->pid = fork();
+	args->pipefd[0] = pipefd[0];
+	args->pipefd[1] = pipefd[1];
+	args->has_fd_redirect_to_stderr = FALSE;
+	if (args->pid < 0)
 	{
 		perror("fork");
 		return (-1);
 	}
-	else if (args.pid == 0)
-		child_process(&args);
+	else if (args->pid == 0)
+		child_process(args);
 	else
-		parent_process(&args);
+		parent_process(args);
 	return (0);
 }

--- a/sources/executor/redirection_utils.c
+++ b/sources/executor/redirection_utils.c
@@ -6,7 +6,7 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/26 08:15:40 by jlacerda          #+#    #+#             */
-/*   Updated: 2025/05/04 18:56:02 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/05/08 23:31:35 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -29,6 +29,7 @@ int	setup_file_input(char *input_file)
 		perror(input_file);
 		return (-1);
 	}
+	manager_file_descriptors(ADD, fd);
 	dup2(fd, STDIN_FILENO);
 	close(fd);
 	return (0);
@@ -135,6 +136,7 @@ int	set_redirection_to_files(t_process_command_args *arg, int *flags)
 			perror(output_file_list[index]);
 			return (-1);
 		}
+		manager_file_descriptors(ADD, fd);
 		if (dup_fd_std(fd, output_file_list[index], arg) < 0)
 		{
 			close(fd);

--- a/sources/free.c
+++ b/sources/free.c
@@ -6,7 +6,7 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/26 14:54:34 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/05/04 19:13:34 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/05/09 00:08:24 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -35,41 +35,28 @@ void	free_env(char **env)
 }
 
 /**
- * @brief Frees the memory allocated for the token content
- * @param content Pointer to the token content to be freed
- * @return void
- * @note Iterates through each token content
-	* and frees its value and the content itself
- */
-void	free_token_content(t_token_content *content)
-{
-	t_token_content	*tmp;
-
-	while (content)
-	{
-		tmp = content;
-		content = content->next;
-		free(tmp->value);
-		free(tmp);
-	}
-}
-
-/**
  * @brief Frees the memory allocated for the token list
  * @param tokens Pointer to the token list to be freed
  * @return void
- * @note Iterates through each token and
-	* frees its content and the token itself
+ * @note Iterates through each token and its content,
+ *       freeing the memory allocated for each
  */
 void	free_tokens(t_token *tokens)
 {
-	t_token	*tmp;
+	t_token			*tmp;
+	t_token_content	*tmp_content;
 
 	while (tokens)
 	{
 		tmp = tokens;
 		tokens = tokens->next;
-		free_token_content(tmp->content);
+		while (tmp->content)
+		{
+			tmp_content = tmp->content;
+			tmp->content = tmp->content->next;
+			free(tmp_content->value);
+			free(tmp_content);
+		}
 		free(tmp);
 	}
 }
@@ -127,5 +114,42 @@ void	exit_free(int signal, char ***envs, t_command *cmds, t_token *tokens)
 		free_commands(cmds);
 	if (tokens)
 		free_tokens(tokens);
+	manager_file_descriptors(FREE, -1);
 	exit(signal);
+}
+
+/**
+	* @brief Manages file descriptors for the shell
+	* @param fd_type Type of operation (ADD or FREE)
+	* @param fd File descriptor to manage
+	* @return void
+	* @note Allocates memory for file descriptors and manages their lifecycle
+	*/
+void	manager_file_descriptors(t_manager_fd fd_type, int fd)
+{
+	static int	fd_index = 0;
+	static int	*fd_list = NULL;
+
+	if (fd_list == NULL)
+	{
+		fd_list = malloc(sizeof(int) * FD_LIST_SIZE);
+		fd_index = 0;
+		while (fd_index < FD_LIST_SIZE)
+			fd_list[fd_index++] = -1;
+		fd_index = 0;
+	}
+	if (fd_type == ADD)
+		fd_list[fd_index++] = fd;
+	else if (fd_type == FREE)
+	{
+		fd_index = 0;
+		while (fd_list[fd_index] > STDERR_FILENO && fd_index < FD_LIST_SIZE)
+		{
+			close(fd_list[fd_index]);
+			fd_list[fd_index] = -1;
+			fd_index++;
+		}
+		free(fd_list);
+		fd_list = NULL;
+	}
 }

--- a/sources/history/file.c
+++ b/sources/history/file.c
@@ -6,7 +6,7 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/13 15:22:25 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/05/04 19:42:53 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/05/08 23:30:22 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -51,6 +51,13 @@ int	open_history_file_read(void)
 	if (!path)
 		return (-1);
 	fd = open(path, O_RDONLY);
+	if (fd < 0)
+	{
+		perror(path);
+		free(path);
+		return (-1);
+	}
+	manager_file_descriptors(ADD, fd);
 	free(path);
 	return (fd);
 }
@@ -70,6 +77,13 @@ int	open_history_file_write(void)
 	if (!path)
 		return (-1);
 	fd = open(path, O_WRONLY | O_CREAT | O_APPEND, 0644);
+	if (fd < 0)
+	{
+		perror(path);
+		free(path);
+		return (-1);
+	}
+	manager_file_descriptors(ADD, fd);
 	free(path);
 	return (fd);
 }

--- a/sources/history/main.c
+++ b/sources/history/main.c
@@ -6,7 +6,7 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/13 11:59:20 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/05/04 19:41:38 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/05/08 23:29:49 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -70,6 +70,7 @@ int	builtin_history(char **args, int *last_exit)
 	free(path);
 	if (fd < 0)
 		return (1);
+	manager_file_descriptors(ADD, fd);
 	display_history_entries(fd);
 	close(fd);
 	return (0);

--- a/sources/main.c
+++ b/sources/main.c
@@ -6,7 +6,7 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/19 19:05:27 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/05/03 17:09:06 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/05/08 23:34:57 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -89,6 +89,7 @@ void	process_input(char *input, char ***env, int *last_exit)
 	set_last_arg_without_pipe_executed(tokens, cmd, env);
 	execute_parsed_commands(cmd, env, last_exit, tokens);
 	free_tokens(tokens);
+	manager_file_descriptors(FREE, -1);
 }
 
 /**

--- a/sources/parser/redirect.c
+++ b/sources/parser/redirect.c
@@ -6,7 +6,7 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/27 19:37:02 by jlacerda          #+#    #+#             */
-/*   Updated: 2025/05/05 23:58:12 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/05/08 23:33:52 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -61,6 +61,7 @@ static int	create_output_file(char *filename, int append)
 		perror(filename);
 		return (0);
 	}
+	manager_file_descriptors(ADD, fd);
 	close(fd);
 	return (1);
 }

--- a/sources/parser/redirect.c
+++ b/sources/parser/redirect.c
@@ -6,7 +6,7 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/27 19:37:02 by jlacerda          #+#    #+#             */
-/*   Updated: 2025/05/08 23:33:52 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/05/09 21:03:21 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,7 +19,7 @@
  * @note Allocates memory for the concatenated
  * delimiter and sets it in the command structure
  */
-static void	process_heredoc_delim(t_token_content *content, t_command	*cmd)
+static void	set_heredoc_delimiter(t_token_content *content, t_command	*cmd)
 {
 	char			*temp;
 	char			*heredoc_delimiter;
@@ -34,6 +34,8 @@ static void	process_heredoc_delim(t_token_content *content, t_command	*cmd)
 		free(temp);
 		tmp_content = tmp_content->next;
 	}
+	if (cmd->heredoc_delim)
+		free(cmd->heredoc_delim);
 	cmd->heredoc_delim = ft_strdup(heredoc_delimiter);
 	free(heredoc_delimiter);
 }
@@ -116,7 +118,10 @@ void	set_redirection_target(t_command *cmd,
 	else if (token->type == APPEND)
 		set_output_redirect_file(filename, cmd, TRUE);
 	else if (token->type == HEREDOC)
-		process_heredoc_delim(content_params->content, cmd);
+	{
+		free(filename);
+		set_heredoc_delimiter(content_params->content, cmd);
+	}
 	else
 		free(filename);
 }

--- a/sources/tokenizer/word_utils.c
+++ b/sources/tokenizer/word_utils.c
@@ -6,7 +6,7 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/22 13:18:28 by jlacerda          #+#    #+#             */
-/*   Updated: 2025/05/02 22:28:30 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/05/09 21:13:45 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -114,16 +114,10 @@ char	*get_word_in_quotes(char *str, int *index, char delimiter)
 t_token_content	*process_word_in_brackets(
 	t_token_content *content, t_tokenizer *tkz)
 {
-	int		malloc_word_len;
-
-	malloc_word_len = ft_strlen(tkz->str + *tkz->str_index);
 	content = add_only_content_word(content, tkz);
 	if (!content && tkz->word_index > 0)
 		return (NULL);
 	free(tkz->word);
-	tkz->word = (char *)malloc(sizeof(char) * (malloc_word_len + 1));
-	if (!tkz->word)
-		return (NULL);
 	tkz->word_index = 0;
 	tkz->word = get_word_in_brackets(tkz->str, tkz->str_index);
 	if (!tkz->word)

--- a/sources/utils.c
+++ b/sources/utils.c
@@ -6,7 +6,7 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/19 19:05:27 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/05/04 19:18:52 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/05/08 22:02:49 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -107,13 +107,6 @@ int	process_tokens(t_token **tokens, int *last_exit)
 void	execute_parsed_commands(t_command *cmd, char ***env, int *last_exit,
 		t_token *tokens)
 {
-	int	saved_stdin;
-	int	saved_stdout;
-	int	saved_stderr;
-
-	saved_stdin = dup(STDIN_FILENO);
-	saved_stdout = dup(STDOUT_FILENO);
-	saved_stderr = dup(STDERR_FILENO);
 	setup_execution_signals();
 	if (!cmd)
 		return ;
@@ -122,12 +115,6 @@ void	execute_parsed_commands(t_command *cmd, char ***env, int *last_exit,
 	else
 		execute_command(cmd, env, last_exit, tokens);
 	setup_interactive_signals();
-	dup2(saved_stdin, STDIN_FILENO);
-	dup2(saved_stdout, STDOUT_FILENO);
-	dup2(saved_stderr, STDERR_FILENO);
-	close(saved_stdout);
-	close(saved_stderr);
-	close(saved_stdin);
 	free_commands(cmd);
 }
 


### PR DESCRIPTION
## Descrição

Este PR resolve o problema de memória "still reachable" que ocorria durante a execução de comandos com pipe no shell. As alterações implementam um sistema centralizado de gerenciamento de descritores de arquivo (FDs) que rastreia, registra e libera adequadamente todos os recursos de sistema utilizados durante o processamento dos comandos.

## Problema Resolvido
Quando executado com Valgrind, o shell apresentava vazamentos do tipo "still reachable" ao utilizar comandos com pipe (`echo | echo`), enquanto comandos simples funcionavam corretamente. Estes vazamentos eram causados por:

1. Descritores de arquivo não fechados adequadamente em processos filhos
2. Estruturas de dados não completamente liberadas durante a execução de pipelines
3. Ausência de gerenciamento centralizado de recursos do sistema

## Solução Implementada

### 1. Sistema de Gerenciamento de Descritores de Arquivo
- Adicionado `manager_file_descriptors()` - função que registra e libera FDs
- Criada enumeração `t_manager_fd` para controlar operações (ADD/FREE)
- Definida constante `FD_LIST_SIZE` para limitar o número de FDs gerenciados

### 2. Refatoração do Processamento de Comandos
- Modificada a função `process_command` para usar a estrutura completa de argumentos
- Adicionado campo `head` na estrutura `t_process_command_args` para manter referência ao comando raiz
- Alterada função `free_tokens` para integrar a lógica de `free_token_content`

### 3. Correções em Processos com Pipe
- Modificados `child_process` e funções relacionadas para liberar todos os recursos
- Implementado registro de FDs em todas as funções que abrem arquivos
- Adicionada chamada a `manager_file_descriptors(FREE, -1)` em pontos estratégicos

## Impacto
- Elimina todos os vazamentos de memória "still reachable" em operações com pipe
- Mantém a compatibilidade com o comportamento existente do shell
- Simplifica o gerenciamento de recursos do sistema

## Testes Realizados

Validado com Valgrind usando as seguintes flags: 

`valgrind --leak-check=full --show-reachable=yes --track-fds=yes --show-leak-kinds=all -s --track-origins=yes --suppressions=./leaks.supp ./minishell`

Promtp testado

`export a="2" | ls | wc -c | printf WTF | sleep 3 | yes loop | head -n 1 | echo 1"2"'3'4${5}$"6"$'7' env | cd ~ | pwd | unset a | echo 1 > file | << eof | cat | echo 2 >> file | cat < file | exit`