### PR TITLE
Implementação de Tratamento Especial para o Comando `cat` antes de `pipe`

### DIFF
--- a/sources/executor/process.c
+++ b/sources/executor/process.c
@@ -6,7 +6,7 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/25 08:19:21 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/05/14 00:18:05 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/05/14 01:18:05 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -49,17 +49,17 @@ static int	handle_empty_command(t_command *cmd)
 	* to the read end of the pipe if there is a next command
 	* in the pipeline.
 	*
-	* TODO: How to the fixes the blocking behavior of the cat command
-	* when used in a pipeline, without ft_strcmp?
+	* TODO: Removing this cat treatment before pipe without
+	* relying on ft_strcmp' will be more elegant.
  */
 static void	set_pipefd_stdin(t_process_command_args *param)
 {
-	int	is_blocking_command;
+	int	is_cat_command;
 
-	is_blocking_command = param->cmd->args
+	is_cat_command = param->cmd->args
 		&& (!ft_strcmp(param->cmd->args[0], "cat")
 			|| !ft_strcmp(param->cmd->args[0], "/bin/cat"));
-	if (is_blocking_command)
+	if (is_cat_command)
 	{
 		close(param->pipefd[1]);
 		close(param->pipefd[0]);

--- a/sources/executor/process.c
+++ b/sources/executor/process.c
@@ -6,7 +6,7 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/25 08:19:21 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/05/09 21:46:27 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/05/14 00:18:05 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -42,14 +42,29 @@ static int	handle_empty_command(t_command *cmd)
 
 /**
  * @brief Sets the standard input file descriptor for the command
- * @param param The command arguments and environment variables
+ * @param param arguments of process for the command
  * @return void
  * @note Closes the pipe file descriptors
-	* and duplicates the read end of the pipe to stdin
+	* and redirects the standard input
+	* to the read end of the pipe if there is a next command
+	* in the pipeline.
+	*
+	* TODO: How to the fixes the blocking behavior of the cat command
+	* when used in a pipeline, without ft_strcmp?
  */
 static void	set_pipefd_stdin(t_process_command_args *param)
 {
-	if (param->cmd->next && param->pipefd[0] > 0)
+	int	is_blocking_command;
+
+	is_blocking_command = param->cmd->args
+		&& (!ft_strcmp(param->cmd->args[0], "cat")
+			|| !ft_strcmp(param->cmd->args[0], "/bin/cat"));
+	if (is_blocking_command)
+	{
+		close(param->pipefd[1]);
+		close(param->pipefd[0]);
+	}
+	else if (param->cmd->next && param->pipefd[0] > 0)
 	{
 		close(param->pipefd[1]);
 		dup2(param->pipefd[0], STDIN_FILENO);


### PR DESCRIPTION
## Resumo
Este PR implementa uma solução específica para o comportamento de bloqueio do comando `cat` quando utilizado em pipelines, adicionando uma lógica de detecção e tratamento especial para este comando.

## Alterações Detalhadas

### 1. Introdução de Detecção de Comandos Bloqueantes
- Adicionada lógica para identificar o comando `cat` e sua versão com caminho completo `/bin/cat`
- Implementada verificação usando `ft_strcmp` para determinar quando aplicar tratamento especial
- Criada variável `is_blocking_command` para melhorar a legibilidade do código

### 2. Tratamento Diferenciado para o Comando `cat`
- Para o comando `cat`, ambos os descritores de pipe são fechados sem realizar redirecionamento
- Esta abordagem previne o comportamento característico do `cat` em pipelines de não esperar pelo encerramento manual da leitura da entrada padrão
- Mantido o tratamento padrão para todos os outros comandos não bloqueantes

### 3. Documentação Aprimorada
- Atualizada a descrição do parâmetro `param` para maior clareza
- Expandida a documentação para explicar com mais detalhes o comportamento da função
- Adicionada nota `TODO` reconhecendo que esta é uma solução temporária e indicando a necessidade de uma abordagem mais elegante no futuro

## Motivação

O comando `cat` sem argumentos tem um comportamento especial: ele espera pela entrada do usuário indefinidamente. Quando usado em pipelines, o cat quando usado em pipes não deve continuar em modo interativo (bloqueante) esperando encerramento manual pelo usuário, deve processar apenas uma leitura e sair automaticamente com `EOF`.

Esta alteração aborda esse problema específico, permitindo que o shell continue funcionando corretamente mesmo quando o usuário executa pipelines contendo o comando `cat`.

## Impacto e Riscos
- **Médio risco**: A solução introduz um tratamento específico para um único comando
- Possível aumento da complexidade do código com casos especiais
- Dependência de comparação de strings para determinar o comportamento

## Próximos Passos
Como indicado pelo TODO adicionado, seria desejável encontrar uma solução mais genérica e elegante para lidar com comandos bloqueantes em pipelines, sem depender de comparações de strings específicas para cada comando.

> O ideal é rever a abordagem de gerenciamento de `fds` dos pipes abertos, garantindo encerramento de todos

## Testes Realizados
- Testados cenários com o comando `cat` em diferentes posições de pipelines
- Confirmado que outros comandos continuam funcionando normalmente