### PR TITLE
Aprimoramento no Tratamento de Códigos de Erro para Redirecionamentos

### DIFF
--- a/sources/executor/command_utils.c
+++ b/sources/executor/command_utils.c
@@ -6,7 +6,7 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/25 08:12:34 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/05/15 21:25:01 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/05/16 00:28:31 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,11 +15,11 @@
 /**
 	* @brief Validates if the given path is executable
 	* @param path The path to validate
-	* @return 0 if valid, 126 if not executable, 127 if not found
-	* @note Uses stat to check if the file exists 
-	* and access to check if it is executable
- */
-static int	validates_executable(char *path)
+	* @param has_redirect_out Indicates if there is a redirection to output
+	* @return 0 if valid, 126 if not executable, 1 or 127 if invalid
+	* @note Checks if the file exists and is executable, and handles errors
+	*/
+static int	validates_executable(char *path, int has_redirect_out)
 {
 	struct stat	path_stat;
 	char		*err_stat;
@@ -32,7 +32,7 @@ static int	validates_executable(char *path)
 		ft_putstr_fd(err_stat, STDERR_FILENO);
 		ft_putendl_fd(": No such file or directory", STDERR_FILENO);
 		free(err_stat);
-		return (1);
+		return (has_redirect_out * 1 + !has_redirect_out * 127);
 	}
 	if ((path[0] == '/' || path[0] == '.') && access(path, X_OK) == 0)
 	{
@@ -119,27 +119,27 @@ int	execute_builtin(t_process_command_args *arg)
 }
 
 /**
- * @brief Executes an external command
- * @param cmd The command to execute
- * @param env The environment variables
- * @return 0 on success, 1 on failure
- * @note Uses execve to execute the command
-	* with the given arguments and environment
- */
-int	execute_external(t_command *cmd, char **env)
+	* @brief Executes an external command
+	* @param cmd The command structure containing the command and its arguments
+	* @param env The environment variables
+	* @param is_redirect Indicates if the command is part of a redirection
+	* @return 0 on success, 1 on failure, or an error code on specific errors
+	* @note Uses execve to execute the command and handles errors appropriately
+	*/
+int	execute_external(t_command *cmd, char **env, int has_redirect_out)
 {
 	char	*cmd_path;
 	char	*command;
-	int		has_signal_validation_executable;
+	int		signal_valites_exec;
 
 	command = cmd->args[0];
 	if (!cmd || !cmd->args || !command || !env)
 		return (1);
 	if (ft_strchr(command, '/'))
 	{
-		has_signal_validation_executable = validates_executable(command);
-		if (has_signal_validation_executable > 0)
-			return (has_signal_validation_executable);
+		signal_valites_exec = validates_executable(command, has_redirect_out);
+		if (signal_valites_exec > 0)
+			return (signal_valites_exec);
 	}
 	if (ft_strcmp(command, "..") == 0)
 		return (invalid_command(command, "command not found"));

--- a/sources/executor/executor.h
+++ b/sources/executor/executor.h
@@ -6,7 +6,7 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/25 08:11:28 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/05/09 20:43:26 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/05/16 00:30:18 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -44,11 +44,12 @@ int		setup_output_redirection(t_process_command_args *param);
 */
 int		is_builtin(char *cmd);
 int		execute_builtin(t_process_command_args *arg);
-int		execute_external(t_command *cmd, char **env);
+int		execute_external(t_command *cmd, char **env, int is_redirect_out);
 
 /*
 ** Process management functions (process.c)
 */
+int		has_redirect_out(t_token	*tokens);
 int		setup_pipe(t_command *cmd, int pipefd[2]);
 int		setup_child_io(t_process_command_args *arg);
 void	child_process(t_process_command_args *param);

--- a/sources/executor/process.c
+++ b/sources/executor/process.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   process.c                                          :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: peda-cos <peda-cos@student.42sp.org.br>    +#+  +:+       +#+        */
+/*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/25 08:19:21 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/05/15 20:14:34 by peda-cos         ###   ########.fr       */
+/*   Updated: 2025/05/16 00:20:16 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -80,14 +80,16 @@ static void	set_pipefd_stdin(t_process_command_args *param)
 }
 
 /**
- * @brief Handles the execution in a child process
+ * @brief Handles the child process execution
  * @param param The command arguments and environment variables
  * @return void
- * @note Sets up signal handling, redirects I/O, and executes the command
+ * @note Sets up the signal handlers, redirects input/output,
+ * and executes the command in the child process.
  */
 void	child_process(t_process_command_args *param)
 {
 	struct sigaction	sa;
+	int					exec_status_signal;
 
 	if (!param->cmd || !param->env || !(param->last_exit))
 		exit_free(1, param->env, param->cmd, param->tokens);
@@ -101,11 +103,14 @@ void	child_process(t_process_command_args *param)
 	if (handle_empty_command(param->cmd))
 		exit_free(0, param->env, param->head, param->tokens);
 	if (is_builtin(param->cmd->args[0]))
-		exit_free(execute_builtin(param), param->env, param->head,
-			param->tokens);
+		exit_free(execute_builtin(param),
+			param->env, param->head, param->tokens);
 	else
-		exit_free(execute_external(param->cmd, *param->env), param->env,
-			param->head, param->tokens);
+	{
+		exec_status_signal = execute_external(
+				param->cmd, *param->env, has_redirect_out(param->tokens));
+		exit_free(exec_status_signal, param->env, param->head, param->tokens);
+	}
 }
 
 /**

--- a/sources/executor/process_utils.c
+++ b/sources/executor/process_utils.c
@@ -6,7 +6,7 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/31 21:56:05 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/05/16 00:10:02 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/05/16 00:34:16 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -61,10 +61,10 @@ int	setup_child_io(t_process_command_args *arg)
 }
 
 /**
-	* @brief Checks if the command has a file input redirection
-	* @param cmd The command structure to check
-	* @return 1 if there is a file input redirection, 0 otherwise
-	* @note Checks the input file list of the command
+	* @brief Checks if the command has output redirection
+	* @param tokens The list of tokens representing the tokens
+	* @return TRUE if there is output redirection, FALSE otherwise
+	* @note Scans through the tokens to find any output redirection types
 	*/
 int	has_redirect_out(t_token	*tokens)
 {

--- a/sources/executor/process_utils.c
+++ b/sources/executor/process_utils.c
@@ -6,7 +6,7 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/31 21:56:05 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/05/04 18:54:23 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/05/16 00:10:02 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -58,4 +58,24 @@ int	setup_child_io(t_process_command_args *arg)
 	if (setup_input_redirection(arg->cmd, *arg->env, *arg->last_exit) < 0)
 		return (-1);
 	return (0);
+}
+
+/**
+	* @brief Checks if the command has a file input redirection
+	* @param cmd The command structure to check
+	* @return 1 if there is a file input redirection, 0 otherwise
+	* @note Checks the input file list of the command
+	*/
+int	has_redirect_out(t_token	*tokens)
+{
+	t_token	*tmp_token;
+
+	tmp_token = tokens;
+	while (tmp_token)
+	{
+		if (tmp_token->type == REDIRECT_OUT || tmp_token->type == APPEND)
+			return (TRUE);
+		tmp_token = tmp_token->next;
+	}
+	return (FALSE);
 }


### PR DESCRIPTION
## Visão Geral
Esta PR implementa uma correção importante no tratamento de códigos de retorno para comandos que não existem ou não são executáveis, especialmente em contextos de redirecionamento, garantindo compatibilidade com o comportamento padrão do Bash.

## Problema Resolvido
No Bash, um comando não encontrado com caminho explícito (como `./comando_inexistente`) retorna:
- Código 127 quando executado normalmente
- Código 1 quando executado com redirecionamento de saída

Nossa implementação anterior retornava sempre o mesmo código, independentemente do contexto, o que causava inconsistências com o comportamento esperado.

## Alterações Implementadas

1. **Função `validates_executable`**:
   - Adicionado parâmetro `has_redirect_out` para detectar redirecionamentos
   - Modificada para retornar o código apropriado baseado no contexto usando a expressão: 
     `has_redirect_out * 1 + !has_redirect_out * 127`

2. **Função `execute_external`**:
   - Atualizada para receber e usar o parâmetro de redirecionamento
   - Melhorada documentação e nomes de variáveis para maior clareza

3. **Nova função `has_redirect_out`**:
   - Implementada para verificar a presença de tokens do tipo `REDIRECT_OUT` ou `APPEND`
   - Retorna TRUE quando encontra redirecionamentos de saída

4. **Função `child_process`**:
   - Modificada para verificar redirecionamentos antes de executar comandos
   - Reorganizada para melhor separação de responsabilidades

## Benefícios
- Comportamento mais consistente com o padrão do Bash
- Melhor integração com scripts e ferramentas externas que dependem dos códigos de erro
- Maior clareza no código através de melhor nomenclatura e documentação

## Testes Realizados
Testados diversos cenários incluindo:
- Comandos inexistentes com e sem redirecionamento
- Comandos com permissões inadequadas
- Combinações de pipes e redirecionamentos