### PR TITLE
Expansão de variável em processamento de heredoc

### DIFF
--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/19 19:15:26 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/05/17 17:31:21 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/05/20 22:19:42 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -62,6 +62,7 @@ int			setup_output_redirection(t_process_command_args *param);
 /* Memory cleanup */
 void		free_tokens(t_token *tokens);
 void		free_commands(t_command *cmd);
+char		*free_and_return(char *str, char *result);
 void		manager_file_descriptors(t_manager_fd fd_type, int fd);
 
 /* Utility for variable expansion */

--- a/sources/executor/executor.h
+++ b/sources/executor/executor.h
@@ -6,7 +6,7 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/25 08:11:28 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/05/17 16:14:10 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/05/20 22:21:51 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -25,15 +25,15 @@ char	*find_executable(char *cmd, char **env);
 /*
 ** Heredoc handling functions (heredoc.c)
 */
-char	*free_and_return(char *str, char *result);
 int		handle_heredoc(char *delim, char **env, int last_exit);
-void	preprocess_heredocs(t_command *cmd_list);
+void	preprocess_heredocs(t_command *cmd_list, char **envs, int *last_exit);
 char	*append_to_buffer(char *buffer, char *line);
 int		is_quoted_delimiter(char *delim);
-char	*process_heredoc_line(char *line, char **env, int last_exit,
-			int expand_vars);
 char	*get_stripped_delim(int expand_vars, char *delim);
-
+char	*process_heredoc_line(char *line,
+			char **env, int last_exit, int expand_vars);
+char	*process_expanded_heredoc(t_command *cmd,
+			char *buffer, char **envs, int *last_exit);
 /*
 ** Redirection handling functions (redirection.c)
 */

--- a/sources/executor/heredoc.c
+++ b/sources/executor/heredoc.c
@@ -6,7 +6,7 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/25 08:12:39 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/05/20 22:20:10 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/05/21 21:31:22 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -58,7 +58,8 @@ static char	*process_heredoc_content(char *stripped_delim,
  * @note Appends each line with newline
 	* character to build complete content
  */
-static char	*read_heredoc_content_to_buffer(char *delim)
+static char	*read_heredoc_content_to_buffer(
+	t_command *cmd, char **envs, int *last_exit)
 {
 	char	*tmp;
 	char	*line;
@@ -68,13 +69,14 @@ static char	*read_heredoc_content_to_buffer(char *delim)
 	while (TRUE)
 	{
 		line = readline("📝 ❯ ");
-		if (!line || !ft_strcmp(line, delim))
+		if (!line || !ft_strcmp(line, cmd->heredoc_delim))
 		{
 			free(line);
 			break ;
 		}
 		tmp = buffer;
 		buffer = ft_strjoin(buffer, line);
+		buffer = process_expanded_heredoc(cmd, buffer, envs, last_exit);
 		free(tmp);
 		tmp = buffer;
 		buffer = ft_strjoin(buffer, "\n");
@@ -160,8 +162,7 @@ void	preprocess_heredocs(t_command *cmd_list, char **envs, int *last_exit)
 		{
 			if (pipe(pipefd) < 0)
 				return (perror("pipe"));
-			buffer = read_heredoc_content_to_buffer(cmd->heredoc_delim);
-			buffer = process_expanded_heredoc(cmd, buffer, envs, last_exit);
+			buffer = read_heredoc_content_to_buffer(cmd, envs, last_exit);
 			if (buffer)
 			{
 				write(pipefd[1], buffer, ft_strlen(buffer));

--- a/sources/executor/heredoc.c
+++ b/sources/executor/heredoc.c
@@ -6,7 +6,7 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/25 08:12:39 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/05/21 21:31:22 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/05/21 22:25:35 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -74,9 +74,9 @@ static char	*read_heredoc_content_to_buffer(
 			free(line);
 			break ;
 		}
+		line = process_expanded_heredoc(cmd, line, envs, last_exit);
 		tmp = buffer;
 		buffer = ft_strjoin(buffer, line);
-		buffer = process_expanded_heredoc(cmd, buffer, envs, last_exit);
 		free(tmp);
 		tmp = buffer;
 		buffer = ft_strjoin(buffer, "\n");

--- a/sources/executor/heredoc.c
+++ b/sources/executor/heredoc.c
@@ -6,7 +6,7 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/25 08:12:39 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/05/17 16:31:37 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/05/20 22:20:10 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -147,7 +147,7 @@ int	handle_heredoc(char *delim, char **env, int last_exit)
  * @note Creates pipes for each command with heredoc delimiter
  *       Stores read file descriptor in command structure
  */
-void	preprocess_heredocs(t_command *cmd_list)
+void	preprocess_heredocs(t_command *cmd_list, char **envs, int *last_exit)
 {
 	t_command	*cmd;
 	char		*buffer;
@@ -161,6 +161,7 @@ void	preprocess_heredocs(t_command *cmd_list)
 			if (pipe(pipefd) < 0)
 				return (perror("pipe"));
 			buffer = read_heredoc_content_to_buffer(cmd->heredoc_delim);
+			buffer = process_expanded_heredoc(cmd, buffer, envs, last_exit);
 			if (buffer)
 			{
 				write(pipefd[1], buffer, ft_strlen(buffer));

--- a/sources/executor/heredoc_utils.c
+++ b/sources/executor/heredoc_utils.c
@@ -6,7 +6,7 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/25 08:12:34 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/05/17 16:13:01 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/05/20 22:21:16 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -100,14 +100,30 @@ char	*get_stripped_delim(int expand_vars, char *delim)
 }
 
 /**
-	* @brief Frees the input string and returns the result string
-	* @param str The string to free
-	* @param result The result string to return
-	* @return The result string
-	* @note Frees the input string after returning the result
+	* @brief Processes the heredoc content and expands variables if necessary
+	* @param cmd The command structure
+	* @param buffer The buffer containing the heredoc content
+	* @param envs The environment variables
+	* @param last_exit The last exit status
+	* @return The processed buffer with expanded variables
+	* @note Uses the expand_variable function to expand variables in the buffer
 	*/
-char	*free_and_return(char *str, char *result)
+char	*process_expanded_heredoc(t_command *cmd,
+	char *buffer, char **envs, int *last_exit)
 {
-	free(str);
-	return (result);
+	char			*temp;
+	int				has_error;
+	t_expansion_ctx	expansion_cxt;
+
+	has_error = FALSE;
+	expansion_cxt.envs = envs;
+	expansion_cxt.last_exit = last_exit;
+	expansion_cxt.has_error_flag_control = &has_error;
+	if (!cmd->in_quotes)
+	{
+		temp = buffer;
+		buffer = expand_variable(temp, &expansion_cxt);
+		free(temp);
+	}
+	return (buffer);
 }

--- a/sources/executor/heredoc_utils.c
+++ b/sources/executor/heredoc_utils.c
@@ -6,7 +6,7 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/25 08:12:34 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/05/20 22:21:16 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/05/21 21:40:56 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -100,30 +100,35 @@ char	*get_stripped_delim(int expand_vars, char *delim)
 }
 
 /**
-	* @brief Processes the heredoc content and expands variables if necessary
+	* @brief Processes the heredoc content
+	* and expands variables if necessary
 	* @param cmd The command structure
-	* @param buffer The buffer containing the heredoc content
+	* @param content The content containing the heredoc content
 	* @param envs The environment variables
 	* @param last_exit The last exit status
-	* @return The processed buffer with expanded variables
-	* @note Uses the expand_variable function to expand variables in the buffer
+	* @return The processed content with expanded variables
+	* @note Uses the expand_variable function
+	* to expand variables in the content
 	*/
 char	*process_expanded_heredoc(t_command *cmd,
-	char *buffer, char **envs, int *last_exit)
+	char *content, char **envs, int *last_exit)
 {
 	char			*temp;
 	int				has_error;
+	int				was_expanded;
 	t_expansion_ctx	expansion_cxt;
 
 	has_error = FALSE;
+	was_expanded = FALSE;
 	expansion_cxt.envs = envs;
 	expansion_cxt.last_exit = last_exit;
+	expansion_cxt.was_expanded = &was_expanded;
 	expansion_cxt.has_error_flag_control = &has_error;
 	if (!cmd->in_quotes)
 	{
-		temp = buffer;
-		buffer = expand_variable(temp, &expansion_cxt);
+		temp = content;
+		content = expand_variable(temp, &expansion_cxt);
 		free(temp);
 	}
-	return (buffer);
+	return (content);
 }

--- a/sources/free.c
+++ b/sources/free.c
@@ -6,11 +6,24 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/26 14:54:34 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/05/09 00:08:24 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/05/20 22:19:01 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
+
+/**
+	* @brief Frees the input string and returns the result string
+	* @param str The string to free
+	* @param result The result string to return
+	* @return The result string
+	* @note Frees the input string after returning the result
+	*/
+char	*free_and_return(char *str, char *result)
+{
+	free(str);
+	return (result);
+}
 
 /**
  * @brief Frees the memory allocated for the environment variables

--- a/sources/main.c
+++ b/sources/main.c
@@ -6,7 +6,7 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/19 19:05:27 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/05/17 17:31:21 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/05/20 21:09:57 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -80,7 +80,7 @@ void	process_input(char *input, char ***env, int *last_exit)
 	if (is_invalid_tokens(&tokens, last_exit))
 		return ;
 	cmd = parse_tokens(tokens, *env, *last_exit);
-	preprocess_heredocs(cmd);
+	preprocess_heredocs(cmd, *env, last_exit);
 	if (cmd == NULL || cmd->args == NULL || *cmd->args[0] == NULL_CHR)
 	{
 		if (process_empty_command(cmd, tokens, last_exit))

--- a/sources/parser/main.c
+++ b/sources/parser/main.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   main.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: peda-cos <peda-cos@student.42sp.org.br>    +#+  +:+       +#+        */
+/*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/26 14:40:39 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/05/15 21:20:43 by peda-cos         ###   ########.fr       */
+/*   Updated: 2025/05/20 21:31:45 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -108,7 +108,8 @@ t_command	*parse_tokens(t_token *tokens, char **env, int last_exit)
 			return (NULL);
 		tokens = next_token;
 	}
-	parser.head->in_quotes = tokens_head->content->in_quotes;
+	if (!parser.head->in_quotes)
+		parser.head->in_quotes = tokens_head->content->in_quotes;
 	if (parser.head && parser.was_expanded)
 	{
 		parser.head->was_expanded = TRUE;

--- a/sources/parser/redirect.c
+++ b/sources/parser/redirect.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   redirect.c                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: peda-cos <peda-cos@student.42sp.org.br>    +#+  +:+       +#+        */
+/*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/27 19:37:02 by jlacerda          #+#    #+#             */
-/*   Updated: 2025/05/15 21:20:47 by peda-cos         ###   ########.fr       */
+/*   Updated: 2025/05/20 22:15:01 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -116,6 +116,7 @@ void	set_redirection_target(t_command *cmd, t_token *token,
 	else if (token->type == HEREDOC)
 	{
 		free(filename);
+		cmd->in_quotes = content_params->content->in_quotes;
 		set_heredoc_delimiter(content_params->content, cmd);
 	}
 	else


### PR DESCRIPTION
## Visão Geral
Este PR implementa suporte para expansão de variáveis em heredocs, alinhando o comportamento do minishell com o bash padrão. Além disso, inclui melhorias na estrutura do código relacionadas ao gerenciamento de memória e tratamento de aspas.

## Alterações Principais

### 1. Suporte a Expansão de Variáveis em Heredocs
- Adicionada função `process_expanded_heredoc` para expandir variáveis no conteúdo do heredoc
- Modificada a função `read_heredoc_content_to_buffer` para processar expansões linha por linha
- Atualizada `preprocess_heredocs` para receber variáveis de ambiente e status de saída

### 2. Melhorias no Gerenciamento de Memória
- Movida a função `free_and_return` para `sources/free.c`, tornando-a uma utilidade global
- Adicionada a declaração no cabeçalho principal para uso em todo o projeto

### 3. Correções no Tratamento de Aspas
- Aprimorado o processamento de aspas no contexto de heredocs
- Modificada a lógica de propagação do flag `in_quotes` para garantir comportamento correto
- Adicionada atribuição explícita de `in_quotes` em redirecionamentos do tipo heredoc

### 4. Reorganização do Código
- Reformatados protótipos de funções para melhor legibilidade
- Melhorada a consistência na documentação de funções
- Ajustada a estrutura de arquivos para melhor separação de responsabilidades

## Benefícios
- Comportamento mais consistente com o bash padrão para heredocs
- Suporte adequado para expansão de variáveis como `$HOME` e `$USER` em heredocs
- Código mais organizado e fácil de manter
- Melhor tratamento de casos especiais envolvendo aspas e expansão

## Impacto da Mudança
Esta mudança afeta o comportamento dos heredocs no shell, permitindo que variáveis sejam expandidas corretamente dentro deles, exceto quando delimitados por aspas simples, conforme esperado pelo comportamento padrão do bash.