### PR TITLE
Corrige problema de compilação e execução com valgrind

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ TOTAL_FILES := $(words $(SRCS))
 COMPILED_COUNT = 0
 BAR_LENGTH = $(TOTAL_FILES)
 
-NO_PROGRESS_BAR ?= false
+progress-bar ?= true
 
 all: header $(NAME)
 
@@ -88,11 +88,12 @@ $(NAME): $(LIBFT) $(OBJS)
 	@rm -f .header_lock
 
 $(LIBFT):
-	@printf "$(BLUE)$(BOLD)🏗️   Compilando libft $(RESET) ...\n"
-ifeq ($(NO_PROGRESS_BAR), true)
+ifeq ($(progress-bar), false)
+	@printf "$(BLUE)$(BOLD)🏗️   Compilando libft $(RESET)"
 	@make -C $(LIBFT_DIR) all
-	@printf "$(GREEN)$(BOLD)✅  Concluído!$(RESET)\n\n"
+	@printf "$(GREEN)$(BOLD)✓ Concluído!$(RESET)\n\n"
 else
+	@printf "$(BLUE)$(BOLD)🏗️   Compilando libft $(RESET)\n"
 	@echo -n "🔄  "
 	@make --no-print-directory -C $(LIBFT_DIR) > /dev/null 2>&1 & \
 	pid=$$!; \
@@ -112,10 +113,10 @@ else
 endif
 
 $(OBJS_DIR)/%.o: %.c
-ifeq ($(NO_PROGRESS_BAR), true)
+ifeq ($(progress-bar), false)
 	@mkdir -p $(dir $@)
 	@$(CC) $(CFLAGS) -c $< -o $@
-	@echo "📄 $(CYAN)$(BOLD)Compiling$(RESET) $<"
+	@echo "📄  $(CYAN)$(BOLD)Compiling$(RESET) $<"
 else
 	@mkdir -p $(dir $@)
 	@$(eval COMPILED_COUNT=$(shell echo $$(($(COMPILED_COUNT)+1))))

--- a/sources/executor/command_chain.c
+++ b/sources/executor/command_chain.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   command_chain.c                                    :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: peda-cos <peda-cos@student.42sp.org.br>    +#+  +:+       +#+        */
+/*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/05 16:18:06 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/06/05 16:28:48 by peda-cos         ###   ########.fr       */
+/*   Updated: 2025/06/07 11:32:41 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -27,6 +27,7 @@ static void	init_command_args(t_process_command_args *args, t_command *cmd_head,
 	args->env = env;
 	args->head = cmd_head;
 	args->tokens = exec_context->tokens;
+	args->has_fd_redirect_to_stderr = FALSE;
 	args->last_exit = exec_context->last_exit;
 }
 

--- a/sources/executor/executor.h
+++ b/sources/executor/executor.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   executor.h                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: peda-cos <peda-cos@student.42sp.org.br>    +#+  +:+       +#+        */
+/*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/25 08:11:28 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/06/05 16:28:53 by peda-cos         ###   ########.fr       */
+/*   Updated: 2025/06/07 11:10:38 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -47,13 +47,15 @@ char			*find_executable(char *cmd, char **env);
 */
 char			*free_and_return(char *str, char *result);
 int				handle_heredoc(char *delim, char **env, int last_exit);
-void			preprocess_heredocs(t_command *cmd_list);
 char			*append_to_buffer(char *buffer, char *line);
 int				is_quoted_delimiter(char *delim);
-char			*process_heredoc_line(char *line, char **env, int last_exit,
-					int expand_vars);
 char			*get_stripped_delim(int expand_vars, char *delim);
-
+void			preprocess_heredocs(t_command *cmd_list,
+					char **envs, int *last_exit);
+char			*process_heredoc_line(char *line,
+					char **env, int last_exit, int expand_vars);
+char			*process_expanded_heredoc(t_command *cmd,
+					char *content, char **envs, int *last_exit);
 /*
 ** Redirection handling functions (redirection.c)
 */


### PR DESCRIPTION
# 🛠️ Melhorias no Sistema de Build e Correções de Bugs

## Resumo
Este PR contempla:

- Correção de compilação devido declarações de funções ausentes
- Correção de valores não inicializados na execução de comandos em pipes, quando processado o builtin `exit`.
- Atualiza variável de compilação sem barra de progresso.

## Mudanças

### 🔄 Melhorias no Sistema de Build
- Renomeado `NO_PROGRESS_BAR` para `progress-bar` para uso mais intuitivo
- Invertida a lógica booleana para instruções condicionais mais claras
- Aprimorada a formatação visual da barra de progresso com espaçamento consistente
- Uso na linha de comando agora é: `make progress-bar=false` em vez de `make NO_PROGRESS_BAR=true`

### 🐛 Correções de Bugs
- Corrigido erro crítico de valor não inicializado em `builtin_exit` (exit.c:51)
  - Inicializa corretamente `has_fd_redirect_to_stderr` em `init_command_args`
  - Previne o erro do Valgrind "Conditional jump or move depends on uninitialised value(s)"
  - Resolve o problema observado ao executar `echo oi | exit 17`

## Testes
- Verificar se o sistema de build funciona com ambos os modos de barra de progresso:
  - Build padrão: `make re`
  - Sem barra de progresso: `make re progress-bar=false`
- Executar Valgrind para confirmar que o erro de valor não inicializado foi corrigido:
  - `make valgrind` e depois digitar `echo oi | exit 17`