### PR TITLE
Refatoração do Sistema de Heredoc e Correção do End of File

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: jlacerda <jlacerda@student.42sp.org.br>    +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2025/02/19 19:01:24 by peda-cos          #+#    #+#              #
-#    Updated: 2025/04/13 15:24:26 by peda-cos         ###   ########.fr        #
+#    Updated: 2025/06/08 06:34:26 by peda-cos         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -32,8 +32,9 @@ EXECUTOR_SRCS = sources/executor/main.c \
 	sources/executor/redirection.c sources/executor/redirection_utils.c \
 	sources/executor/command_utils.c sources/executor/process.c \
 	sources/executor/heredoc.c sources/executor/heredoc_utils.c \
-	sources/executor/pipe_handler.c sources/executor/execution_setup.c \
-	sources/executor/command_chain.c sources/executor/pipe_fork.c \
+	sources/executor/heredoc_helper.c sources/executor/pipe_handler.c \
+	sources/executor/execution_setup.c sources/executor/command_chain.c \
+	sources/executor/pipe_fork.c \
 	sources/executor/pipe_chain.c sources/executor/pipe_wait.c
 TOKENIZER_SRCS = sources/tokenizer/main.c \
 	sources/tokenizer/utils.c sources/tokenizer/redirect.c sources/tokenizer/token.c \

--- a/sources/executor/executor.h
+++ b/sources/executor/executor.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   executor.h                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
+/*   By: peda-cos <peda-cos@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/25 08:11:28 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/06/07 11:10:38 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/06/08 06:37:28 by peda-cos         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,6 +15,18 @@
 
 # include "minishell.h"
 # include <sys/stat.h>
+
+/*
+** Structure for heredoc processing context to reduce function arguments
+*/
+typedef struct s_heredoc_ctx
+{
+	char		*stripped_delim;
+	int			expand_vars;
+	char		**envs;
+	int			*last_exit;
+	t_command	*cmd;
+}				t_heredoc_ctx;
 
 /*
 ** Structure for pipe information to reduce function arguments
@@ -50,12 +62,25 @@ int				handle_heredoc(char *delim, char **env, int last_exit);
 char			*append_to_buffer(char *buffer, char *line);
 int				is_quoted_delimiter(char *delim);
 char			*get_stripped_delim(int expand_vars, char *delim);
-void			preprocess_heredocs(t_command *cmd_list,
+void			preprocess_heredocs(t_command *cmd_list, char **envs,
+					int *last_exit);
+char			*process_heredoc_line(char *line, char **env, int last_exit,
+					int expand_vars);
+char			*process_expanded_heredoc(t_command *cmd, char *content,
 					char **envs, int *last_exit);
-char			*process_heredoc_line(char *line,
-					char **env, int last_exit, int expand_vars);
-char			*process_expanded_heredoc(t_command *cmd,
-					char *content, char **envs, int *last_exit);
+
+/*
+** Heredoc helper functions (heredoc_helper.c)
+*/
+void			display_heredoc_eof_warning(char *delimiter);
+char			*process_buffer_line(t_heredoc_ctx *ctx, char *line,
+					char *buffer);
+char			*process_single_heredoc_line(t_heredoc_ctx *ctx, char *line,
+					char *buffer);
+int				process_single_command_heredoc(t_command *cmd,
+					t_heredoc_ctx *ctx);
+char			*read_heredoc_content_to_buffer(t_heredoc_ctx *ctx);
+
 /*
 ** Redirection handling functions (redirection.c)
 */

--- a/sources/executor/heredoc_helper.c
+++ b/sources/executor/heredoc_helper.c
@@ -1,0 +1,135 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   heredoc_helper.c                                   :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: peda-cos <peda-cos@student.42sp.org.br>    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/06/08 06:32:27 by peda-cos          #+#    #+#             */
+/*   Updated: 2025/06/08 06:37:29 by peda-cos         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "executor.h"
+
+/**
+ * @brief Displays EOF warning message for heredoc
+ * @param delimiter The delimiter that was expected
+ * @note Prints warning when heredoc is terminated by EOF instead of delimiter
+ */
+void	display_heredoc_eof_warning(char *delimiter)
+{
+	ft_putstr_fd("minishell: warning: here-document delimited by ",
+		STDERR_FILENO);
+	ft_putstr_fd("end-of-file (wanted `", STDERR_FILENO);
+	ft_putstr_fd(delimiter, STDERR_FILENO);
+	ft_putstr_fd("')\n", STDERR_FILENO);
+}
+
+/**
+ * @brief Processes a single line in heredoc buffer
+ * @param ctx The heredoc context structure
+ * @param line The input line
+ * @param buffer The current buffer
+ * @return Updated buffer with processed line
+ */
+char	*process_buffer_line(t_heredoc_ctx *ctx, char *line, char *buffer)
+{
+	char	*tmp;
+
+	line = process_expanded_heredoc(ctx->cmd, line, ctx->envs, ctx->last_exit);
+	tmp = buffer;
+	buffer = ft_strjoin(buffer, line);
+	free(tmp);
+	tmp = buffer;
+	buffer = ft_strjoin(buffer, "\n");
+	free(tmp);
+	free(line);
+	return (buffer);
+}
+
+/**
+ * @brief Processes a single line from heredoc input
+ * @param ctx The heredoc processing context
+ * @param line The input line to process
+ * @param buffer The current buffer to append to
+ * @return Updated buffer with processed line, or NULL on error
+ */
+char	*process_single_heredoc_line(t_heredoc_ctx *ctx, char *line,
+		char *buffer)
+{
+	char	*processed_line;
+
+	if (!ft_strcmp(line, ctx->stripped_delim))
+		return (free_and_return(line, buffer));
+	processed_line = process_heredoc_line(line, ctx->envs, *ctx->last_exit,
+			ctx->expand_vars);
+	free(line);
+	if (!processed_line)
+		return (free_and_return(buffer, NULL));
+	buffer = append_to_buffer(buffer, processed_line);
+	free(processed_line);
+	if (!buffer)
+		return (NULL);
+	return (buffer);
+}
+
+/**
+ * @brief Reads heredoc content from the user until delimiter is encountered
+ * @param ctx The heredoc processing context
+ * @return Dynamically allocated string containing heredoc content
+ * @note Appends each line with newline character to build complete content
+ */
+char	*read_heredoc_content_to_buffer(t_heredoc_ctx *ctx)
+{
+	char	*line;
+	char	*buffer;
+
+	buffer = ft_strdup("");
+	while (TRUE)
+	{
+		line = readline("📝 ❯ ");
+		if (!line)
+		{
+			display_heredoc_eof_warning(ctx->cmd->heredoc_delim);
+			free(line);
+			break ;
+		}
+		if (!ft_strcmp(line, ctx->cmd->heredoc_delim))
+		{
+			free(line);
+			break ;
+		}
+		buffer = process_buffer_line(ctx, line, buffer);
+	}
+	return (buffer);
+}
+
+/**
+ * @brief Processes heredoc for a single command
+ * @param cmd The command to process
+ * @param ctx The heredoc processing context
+ * @return 0 on success, -1 on error
+ * @note Creates a pipe and processes the heredoc content for the command
+ */
+int	process_single_command_heredoc(t_command *cmd, t_heredoc_ctx *ctx)
+{
+	char	*buffer;
+	int		pipefd[2];
+
+	if (pipe(pipefd) < 0)
+	{
+		perror("pipe");
+		return (-1);
+	}
+	ctx->cmd = cmd;
+	buffer = read_heredoc_content_to_buffer(ctx);
+	if (buffer)
+	{
+		write(pipefd[1], buffer, ft_strlen(buffer));
+		free(buffer);
+	}
+	close(pipefd[1]);
+	cmd->heredoc_fd = pipefd[0];
+	return (0);
+}


### PR DESCRIPTION
## 📋 Resumo

Esta PR refatora o sistema de processamento de heredoc do projeto, extraindo funcionalidades em funções auxiliares menores e mais específicas para melhorar a legibilidade, manutenibilidade e organização do código.

## 🎯 Objetivo

- Reduzir a complexidade das funções existentes no módulo heredoc
- Melhorar a organização do código através da separação de responsabilidades
- Introduzir uma estrutura de contexto para reduzir a quantidade de parâmetros

## 🔧 Principais Alterações

### 📁 **Makefile**
- Adicionado `sources/executor/heredoc_helper.c` aos arquivos fonte do executor

### 📁 **sources/executor/executor.h**
- **Nova estrutura:** `t_heredoc_ctx` para contexto de processamento de heredoc
- **Novas declarações de funções auxiliares:**
  - `display_heredoc_eof_warning()`
  - `process_buffer_line()`
  - `process_single_heredoc_line()`
  - `process_single_command_heredoc()`
  - `read_heredoc_content_to_buffer()`

### 📁 **sources/executor/heredoc.c**
- **Refatoração da função `process_heredoc_content()`:**
  - Utiliza nova estrutura de contexto `t_heredoc_ctx`
  - Delega processamento de linhas para funções auxiliares
- **Simplificação da função `read_heredoc_content()`:**
  - Usa estrutura de contexto para organizar parâmetros
- **Atualização da função `preprocess_heredocs()`:**
  - Utiliza funções auxiliares para processamento individual de comandos

### 📁 **sources/executor/heredoc_helper.c** *(NOVO ARQUIVO)*
- **`display_heredoc_eof_warning()`:** Exibe aviso quando heredoc é terminado por EOF
- **`process_buffer_line()`:** Processa uma linha individual no buffer
- **`process_single_heredoc_line()`:** Processa linha única da entrada heredoc
- **`read_heredoc_content_to_buffer()`:** Lê conteúdo completo do heredoc
- **`process_single_command_heredoc()`:** Processa heredoc para um comando específico

## ✨ Benefícios

### 🧹 **Código Mais Limpo**
- Funções menores e com responsabilidades bem definidas
- Eliminação de código duplicado
- Melhor legibilidade através da separação lógica

### 🔧 **Manutenibilidade**
- Facilita modificações futuras no sistema de heredoc
- Permite testes unitários mais específicos
- Reduz o acoplamento entre componentes

### 📦 **Organização**
- Nova estrutura `t_heredoc_ctx` centraliza parâmetros relacionados
- Arquivo dedicado para funções auxiliares (`heredoc_helper.c`)
- Interface mais clara e consistente