### PR TITLE
Implementa detecção de aspas não fechadas no tokenizer

### DIFF
--- a/includes/structs.h
+++ b/includes/structs.h
@@ -6,7 +6,7 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/20 22:48:48 by jlacerda          #+#    #+#             */
-/*   Updated: 2025/05/14 22:10:44 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/06/08 21:15:36 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -93,6 +93,7 @@ typedef struct s_token
 	struct s_token			*next;
 	t_token_content			*content;
 	int						length;
+	int						has_unclosed_quotes;
 }							t_token;
 
 /**

--- a/sources/tokenizer/utils.c
+++ b/sources/tokenizer/utils.c
@@ -6,7 +6,7 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/22 13:18:28 by jlacerda          #+#    #+#             */
-/*   Updated: 2025/05/04 19:08:56 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/06/08 21:15:36 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -67,6 +67,7 @@ t_token	*new_token(t_token_content *content, t_token_type type)
 	token->next = NULL;
 	token->type = type;
 	token->content = content;
+	token->has_unclosed_quotes = FALSE;
 	tmp_content = content;
 	while (tmp_content)
 	{

--- a/sources/tokenizer/word.c
+++ b/sources/tokenizer/word.c
@@ -6,7 +6,7 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/22 13:18:28 by jlacerda          #+#    #+#             */
-/*   Updated: 2025/05/17 17:25:27 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/06/08 21:15:36 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -123,4 +123,6 @@ void	add_token_word(char *str, int *index, t_token **tokens)
 	free(tkz.word);
 	if (content)
 		add_token(tokens, new_token(content, WORD));
+	else
+		(*tokens)->has_unclosed_quotes = TRUE;
 }

--- a/sources/tokenizer/word.c
+++ b/sources/tokenizer/word.c
@@ -6,7 +6,7 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/22 13:18:28 by jlacerda          #+#    #+#             */
-/*   Updated: 2025/06/08 21:15:36 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/06/10 21:51:04 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -123,6 +123,6 @@ void	add_token_word(char *str, int *index, t_token **tokens)
 	free(tkz.word);
 	if (content)
 		add_token(tokens, new_token(content, WORD));
-	else
+	else if (tokens && *tokens)
 		(*tokens)->has_unclosed_quotes = TRUE;
 }

--- a/sources/validator/main.c
+++ b/sources/validator/main.c
@@ -6,7 +6,7 @@
 /*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/05 17:03:12 by jlacerda          #+#    #+#             */
-/*   Updated: 2025/05/04 19:11:35 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/06/08 21:15:36 by jlacerda         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -45,6 +45,8 @@ int	validate_tokens(t_token **tokens)
 			return (print_syntax_error(token->content->value));
 		if (is_redirection(token->type) && !is_valid_redirection(token))
 			return (print_syntax_error(token->content->value));
+		if (token->has_unclosed_quotes)
+			return (TRUE);
 		token = token->next;
 	}
 	return (FALSE);


### PR DESCRIPTION
# Implementa detecção de aspas não fechadas no tokenizer

## 🔍 Descrição
Este PR adiciona suporte para detecção de aspas não fechadas durante o processo de tokenização de comandos. Anteriormente, aspas não fechadas podiam causar comportamento inesperado no shell. Com esta implementação, o shell agora pode identificar corretamente situações em que um comando contém aspas que não foram fechadas apropriadamente.

## 🛠️ Mudanças
- Adiciona um novo campo `has_unclosed_quotes` na estrutura `t_token`
- Inicializa esse campo como `FALSE` na criação de cada token
- Define esse campo como `TRUE` quando uma palavra com aspas não fechadas é detectada
- Adiciona uma verificação no validador para identificar tokens com aspas não fechadas

## 🧪 Testes realizados
- Testado com comandos contendo aspas simples não fechadas (`'`)
- Testado com comandos contendo aspas duplas não fechadas (`"`)
- Verificado que a validação interrompe o processamento quando aspas não fechadas são detectadas
- Testado com comandos válidos para garantir que o comportamento normal não foi afetado

## 📚 Código impactado
- `includes/structs.h`: Adição do campo na estrutura
- `sources/tokenizer/utils.c`: Inicialização do novo campo
- `sources/tokenizer/word.c`: Detecção de aspas não fechadas durante tokenização
- `sources/validator/main.c`: Validação de tokens com aspas não fechadas

## 📈 Benefícios
- Melhora a robustez do shell ao lidar com comandos mal formados
- Previne comportamentos inesperados causados por aspas não fechadas
- Proporciona feedback mais claro para o usuário quando há erros de sintaxe

## ⚠️ Possíveis problemas
- Nenhum identificado até o momento

## 📝 Notas
- Esta implementação **NÃO** segue o comportamento padrão do bash, que abre um ´heredoc´ para obter o conteúdo até identificar a aspa delimitante.
- Esta abordagem busca apenas sinalizar o usuário de aspas não fechadas registrando error no terminal

closes #79 